### PR TITLE
Storage get

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -40,7 +40,7 @@ var facadeVersions = map[string]int{
 	"Upgrader":             0,
 	"Firewaller":           1,
 	"Rsyslog":              0,
-	"Uniter":               1,
+	"Uniter":               2,
 	"Action":               0,
 	"Service":              1,
 	"EnvironmentManager":   1,

--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+)
+
+type StorageAccessor struct {
+	facade base.FacadeCaller
+}
+
+// NewStorageAccessor creates a StorageAccessor on the specified facade,
+// and uses this name when calling through the caller.
+func NewStorageAccessor(facade base.FacadeCaller) *StorageAccessor {
+	return &StorageAccessor{facade}
+}
+
+func (sa *StorageAccessor) StorageInstances(unitTag names.Tag) ([]storage.StorageInstance, error) {
+	if sa.facade.BestAPIVersion() < 2 {
+		// StorageInstances() was introduced in UniterAPIV2.
+		return nil, errors.NotImplementedf("StorageInstances() (need V2+)")
+	}
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: unitTag.String()},
+		},
+	}
+	var results params.UnitStorageInstancesResults
+	err := sa.facade.FacadeCall("UnitStorageInstances", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.UnitsStorageInstances) != 1 {
+		panic(errors.Errorf("expected 1 result, got %d", len(results.UnitsStorageInstances)))
+	}
+	storageInstances := results.UnitsStorageInstances[0]
+	if storageInstances.Error != nil {
+		return nil, storageInstances.Error
+	}
+	return storageInstances.Instances, nil
+}

--- a/api/uniter/storage.go
+++ b/api/uniter/storage.go
@@ -22,6 +22,7 @@ func NewStorageAccessor(facade base.FacadeCaller) *StorageAccessor {
 	return &StorageAccessor{facade}
 }
 
+// StorageInstances returns the storage instances for a unit.
 func (sa *StorageAccessor) StorageInstances(unitTag names.Tag) ([]storage.StorageInstance, error) {
 	if sa.facade.BestAPIVersion() < 2 {
 		// StorageInstances() was introduced in UniterAPIV2.

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -5,6 +5,7 @@ package uniter_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/names"
 )
 
 var _ = gc.Suite(&storageSuite{})

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/storage"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/names"
+)
+
+var _ = gc.Suite(&storageSuite{})
+
+type storageSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *storageSuite) TestStorageInstances(c *gc.C) {
+	storageInstances := []params.UnitStorageInstances{
+		{
+			Instances: []storage.StorageInstance{
+				{Id: "whatever", Kind: storage.StorageKindBlock, Location: "/dev/sda"},
+			},
+		},
+	}
+
+	var called bool
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Uniter")
+		c.Check(version, gc.Equals, 2)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "UnitStorageInstances")
+		c.Check(arg, gc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{Tag: "unit-mysql-0"}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.UnitStorageInstancesResults{})
+		*(result.(*params.UnitStorageInstancesResults)) = params.UnitStorageInstancesResults{
+			storageInstances,
+		}
+		called = true
+		return nil
+	})
+
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	instances, err := st.StorageInstances(names.NewUnitTag("mysql/0"))
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+	c.Assert(instances, gc.DeepEquals, storageInstances[0].Instances)
+}
+
+func (s *storageSuite) TestStorageInstanceResultCountMismatch(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.UnitStorageInstancesResults)) = params.UnitStorageInstancesResults{
+			[]params.UnitStorageInstances{{}, {}},
+		}
+		return nil
+	})
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	c.Assert(func() { st.StorageInstances(names.NewUnitTag("mysql/0")) }, gc.PanicMatches, "expected 1 result, got 2")
+}
+
+func (s *storageSuite) TestAPIErrors(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return errors.New("bad")
+	})
+	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
+	_, err := st.StorageInstances(names.NewUnitTag("mysql/0"))
+	c.Check(err, gc.ErrorMatches, "bad")
+}

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -22,6 +22,7 @@ const uniterFacade = "Uniter"
 type State struct {
 	*common.EnvironWatcher
 	*common.APIAddresser
+	*StorageAccessor
 
 	facade base.FacadeCaller
 	// unitTag contains the authenticated unit's tag.
@@ -41,10 +42,11 @@ func newStateForVersion(
 		version,
 	)
 	return &State{
-		EnvironWatcher: common.NewEnvironWatcher(facadeCaller),
-		APIAddresser:   common.NewAPIAddresser(facadeCaller),
-		facade:         facadeCaller,
-		unitTag:        authTag,
+		EnvironWatcher:  common.NewEnvironWatcher(facadeCaller),
+		APIAddresser:    common.NewAPIAddresser(facadeCaller),
+		StorageAccessor: NewStorageAccessor(facadeCaller),
+		facade:          facadeCaller,
+		unitTag:         authTag,
 	}
 }
 
@@ -58,9 +60,14 @@ func newStateV1(caller base.APICaller, authTag names.UnitTag) *State {
 	return newStateForVersion(caller, authTag, 1)
 }
 
+// newStateV2 creates a new client-side Uniter facade, version 2.
+func newStateV2(caller base.APICaller, authTag names.UnitTag) *State {
+	return newStateForVersion(caller, authTag, 2)
+}
+
 // NewState creates a new client-side Uniter facade.
 // Defined like this to allow patching during tests.
-var NewState = newStateV1
+var NewState = newStateV2
 
 // BestAPIVersion returns the API version that we were able to
 // determine is supported by both the client and the API Server.

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -199,6 +199,7 @@ func storageStorageInstance(st state.StorageInstance) (storage.StorageInstance, 
 	return storage.StorageInstance{
 		st.Id(),
 		storageStorageKind(st.Kind()),
+		"", // TODO(wallyworld) Location
 	}, nil
 }
 

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -847,3 +847,12 @@ type StorageInstanceResult struct {
 type StorageInstanceResults struct {
 	Results []StorageInstanceResult `json:"results,omitempty"`
 }
+
+type UnitStorageInstances struct {
+	Instances []storage.StorageInstance `json:"instances,omitempty"`
+	Error     *Error                    `json:"error,omitempty"`
+}
+
+type UnitStorageInstancesResults struct {
+	UnitsStorageInstances []UnitStorageInstances `json:"unitstorageinstances,omitempty"`
+}

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -848,11 +848,13 @@ type StorageInstanceResults struct {
 	Results []StorageInstanceResult `json:"results,omitempty"`
 }
 
+// UnitStorageInstances holds the storage instances for a given unit.
 type UnitStorageInstances struct {
 	Instances []storage.StorageInstance `json:"instances,omitempty"`
 	Error     *Error                    `json:"error,omitempty"`
 }
 
+// UnitStorageInstancesResults holds the result of a StorageInstances call for a unit.
 type UnitStorageInstancesResults struct {
 	UnitsStorageInstances []UnitStorageInstances `json:"unitstorageinstances,omitempty"`
 }

--- a/apiserver/uniter/state.go
+++ b/apiserver/uniter/state.go
@@ -1,0 +1,29 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/juju/state"
+)
+
+type storageStateInterface interface {
+	StorageInstance(id string) (state.StorageInstance, error)
+	Unit(name string) (*state.Unit, error)
+}
+
+type storageStateShim struct {
+	*state.State
+}
+
+var getStorageState = func(st *state.State) storageStateInterface {
+	return storageStateShim{st}
+}
+
+func (s storageStateShim) StorageInstance(id string) (state.StorageInstance, error) {
+	return s.State.StorageInstance(id)
+}
+
+func (s storageStateShim) Unit(name string) (*state.Unit, error) {
+	return s.State.Unit(name)
+}

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -33,6 +33,7 @@ func NewStorageAPI(
 	}, nil
 }
 
+// UnitStorageInstances returns the storage instances for a collection of units.
 func (s *StorageAPI) UnitStorageInstances(args params.Entities) (params.UnitStorageInstancesResults, error) {
 	canAccess, err := s.accessUnit()
 	if err != nil {

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/names"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+)
+
+// StorageAPI provides access to the Storage API facade.
+type StorageAPI struct {
+	st         storageStateInterface
+	resources  *common.Resources
+	accessUnit common.GetAuthFunc
+}
+
+// NewStorageAPI creates a new server-side Storage API facade.
+func NewStorageAPI(
+	st *state.State,
+	resources *common.Resources,
+	accessUnit common.GetAuthFunc,
+) (*StorageAPI, error) {
+
+	return &StorageAPI{
+		st:         getStorageState(st),
+		resources:  resources,
+		accessUnit: accessUnit,
+	}, nil
+}
+
+func (s *StorageAPI) UnitStorageInstances(args params.Entities) (params.UnitStorageInstancesResults, error) {
+	canAccess, err := s.accessUnit()
+	if err != nil {
+		return params.UnitStorageInstancesResults{}, err
+	}
+	result := params.UnitStorageInstancesResults{
+		UnitsStorageInstances: make([]params.UnitStorageInstances, len(args.Entities)),
+	}
+	for i, entity := range args.Entities {
+		result.UnitsStorageInstances[i] = s.getOneUnitStorageInstances(canAccess, entity.Tag)
+	}
+	return result, nil
+}
+
+func (s *StorageAPI) getOneUnitStorageInstances(canAccess common.AuthFunc, unitTag string) params.UnitStorageInstances {
+	tag, err := names.ParseUnitTag(unitTag)
+	if err != nil {
+		return params.UnitStorageInstances{Error: common.ServerError(common.ErrPerm)}
+	}
+	if !canAccess(tag) {
+		return params.UnitStorageInstances{Error: common.ServerError(common.ErrPerm)}
+	}
+	unit, err := s.st.Unit(tag.Id())
+	if err != nil {
+		return params.UnitStorageInstances{Error: common.ServerError(common.ErrPerm)}
+	}
+	var result params.UnitStorageInstances
+	for _, storageId := range unit.StorageInstanceIds() {
+		stateStorageInstance, err := s.st.StorageInstance(storageId)
+		if err != nil {
+			result.Error = common.ServerError(err)
+			result.Instances = nil
+			break
+		}
+		storageInstance := storage.StorageInstance{
+			stateStorageInstance.Id(),
+			storage.StorageKind(stateStorageInstance.Kind()),
+			"", //TODO - add Location
+		}
+		result.Instances = append(result.Instances, storageInstance)
+	}
+	return result
+}

--- a/apiserver/uniter/uniter_v2.go
+++ b/apiserver/uniter/uniter_v2.go
@@ -20,7 +20,7 @@ type UniterAPIV2 struct {
 	StorageAPI
 }
 
-// NewUniterAPIV2 creates a new instance of the Uniter API, version 1.
+// NewUniterAPIV2 creates a new instance of the Uniter API, version 2.
 func NewUniterAPIV2(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UniterAPIV2, error) {
 	baseAPI, err := NewUniterAPIV1(st, resources, authorizer)
 	if err != nil {

--- a/apiserver/uniter/uniter_v2.go
+++ b/apiserver/uniter/uniter_v2.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// The uniter package implements the API interface used by the uniter
+// worker. This file contains the API facade version 2.
+package uniter
+
+import (
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/state"
+)
+
+func init() {
+	common.RegisterStandardFacade("Uniter", 2, NewUniterAPIV2)
+}
+
+// UniterAPI implements the API version 2, used by the uniter worker.
+type UniterAPIV2 struct {
+	UniterAPIV1
+	StorageAPI
+}
+
+// NewUniterAPIV2 creates a new instance of the Uniter API, version 1.
+func NewUniterAPIV2(st *state.State, resources *common.Resources, authorizer common.Authorizer) (*UniterAPIV2, error) {
+	baseAPI, err := NewUniterAPIV1(st, resources, authorizer)
+	if err != nil {
+		return nil, err
+	}
+	storageAPI, err := NewStorageAPI(st, resources, baseAPI.accessUnit)
+	if err != nil {
+		return nil, err
+	}
+	return &UniterAPIV2{
+		UniterAPIV1: *baseAPI,
+		StorageAPI:  *storageAPI,
+	}, nil
+}

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/uniter"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	jujufactory "github.com/juju/juju/testing/factory"
+)
+
+//TODO run all common V0 and V1 tests.
+type uniterV2Suite struct {
+	uniterBaseSuite
+	uniter *uniter.UniterAPIV2
+}
+
+var _ = gc.Suite(&uniterV2Suite{})
+
+func (s *uniterV2Suite) SetUpTest(c *gc.C) {
+	s.uniterBaseSuite.setUpTest(c)
+
+	uniterAPIV2, err := uniter.NewUniterAPIV2(
+		s.State,
+		s.resources,
+		s.authorizer,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	s.uniter = uniterAPIV2
+}
+
+func (s *uniterV2Suite) TestStorageInstances(c *gc.C) {
+	// We need to set up a unit that has storage metadata defined.
+	ch := s.AddTestingCharm(c, "storage-block")
+	sCons := map[string]state.StorageConstraints{
+		"data": state.StorageConstraints{Pool: "", Size: 1024, Count: 1},
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
+	factory := jujufactory.NewFactory(s.State)
+	unit := factory.MakeUnit(c, &jujufactory.UnitParams{
+		Service: service,
+	})
+
+	password, err := utils.RandomPassword()
+	err = unit.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	st := s.OpenAPIAs(c, unit.Tag(), password)
+	uniter, err := st.Uniter()
+	c.Assert(err, jc.ErrorIsNil)
+	instances, err := uniter.StorageInstances(unit.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instances, gc.DeepEquals, []storage.StorageInstance{
+		{Id: "data/0", Kind: storage.StorageKindBlock, Location: ""},
+	})
+}

--- a/cmd/juju/helptool.go
+++ b/cmd/juju/helptool.go
@@ -64,7 +64,11 @@ func (dummyHookContext) RequestReboot(prio jujuc.RebootPriority) error {
 	return nil
 }
 
-func (dummyHookContext) StorageInstances() ([]storage.StorageInstance, bool) {
+func (dummyHookContext) HookStorageInstance() (*storage.StorageInstance, bool) {
+	return nil, false
+}
+
+func (dummyHookContext) StorageInstance(id string) (*storage.StorageInstance, bool) {
 	return nil, false
 }
 

--- a/cmd/juju/helptool.go
+++ b/cmd/juju/helptool.go
@@ -12,6 +12,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -61,6 +62,10 @@ func (dummyHookContext) RelationIds() []int {
 
 func (dummyHookContext) RequestReboot(prio jujuc.RebootPriority) error {
 	return nil
+}
+
+func (dummyHookContext) StorageInstances() ([]storage.StorageInstance, bool) {
+	return nil, false
 }
 
 func (dummyHookContext) OwnerTag() string {

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -122,6 +122,7 @@ All hooks can directly use the following tools:
   * relation-set (write the local unit's relation settings)
   * relation-ids (list all relations using a given charm relation)
   * relation-list (list all units of a related service)
+  * storage-get (get storage instance values)
 
 Within the context of a single hook execution, the above tools present a
 sandboxed view of the system with the following properties:

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -545,6 +545,13 @@ func (s *JujuConnSuite) AddTestingService(c *gc.C, name string, ch *state.Charm)
 	return s.AddTestingServiceWithNetworks(c, name, ch, nil)
 }
 
+func (s *JujuConnSuite) AddTestingServiceWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Service {
+	owner := s.AdminUserTag(c).String()
+	service, err := s.State.AddService(name, owner, ch, nil, storage)
+	c.Assert(err, jc.ErrorIsNil)
+	return service
+}
+
 func (s *JujuConnSuite) AddTestingServiceWithNetworks(c *gc.C, name string, ch *state.Charm, networks []string) *state.Service {
 	c.Assert(s.State, gc.NotNil)
 	owner := s.AdminUserTag(c).String()

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -28,8 +28,11 @@ func (k StorageKind) String() string {
 // unit.
 type StorageInstance struct {
 	// Id is a unique name assigned by Juju to the storage instance.
-	Id string `yaml:"id"`
+	Id string `yaml:"id" json:"id"`
 
 	// Kind is the kind of the datastore (block device, filesystem).
-	Kind StorageKind `yaml:"kind"`
+	Kind StorageKind `yaml:"kind" json:"kind"`
+
+	// Location is the location relevant to the datastore (block device, filesystem).
+	Location string `yaml:"location" json:"location"`
 }

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -35,8 +35,8 @@ type Info struct {
 	// be retrieved by RunHook.
 	ActionId string `yaml:"action-id,omitempty"`
 
-	// StorageIds is the ids of storage instances relevant to the hook.
-	StorageIds []string `yaml:"storage-ids,omitempty"`
+	// StorageId is the id of the storage instance relevant to the hook.
+	StorageId string `yaml:"storage-id,omitempty"`
 }
 
 // Validate returns an error if the info is not valid.
@@ -56,7 +56,7 @@ func (hi Info) Validate() error {
 		return nil
 	case hooks.StorageAttached, hooks.StorageDetached:
 		// TODO: stop checking feature flag once storage has graduated.
-		if true || featureflag.Enabled(storage.FeatureFlag) {
+		if featureflag.Enabled(storage.FeatureFlag) {
 			return nil
 		}
 	}

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -7,6 +7,9 @@ package hook
 import (
 	"fmt"
 
+	"github.com/juju/utils/featureflag"
+
+	"github.com/juju/juju/storage"
 	"github.com/juju/names"
 	"gopkg.in/juju/charm.v4/hooks"
 )
@@ -31,6 +34,9 @@ type Info struct {
 	// ActionId is the state State.actions ID of the Action document to
 	// be retrieved by RunHook.
 	ActionId string `yaml:"action-id,omitempty"`
+
+	// StorageIds is the ids of storage instances relevant to the hook.
+	StorageIds []string `yaml:"storage-ids,omitempty"`
 }
 
 // Validate returns an error if the info is not valid.
@@ -48,6 +54,11 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("action id %q cannot be parsed as an action tag", hi.ActionId)
 		}
 		return nil
+	case hooks.StorageAttached, hooks.StorageDetached:
+		// TODO: stop checking feature flag once storage has graduated.
+		if true || featureflag.Enabled(storage.FeatureFlag) {
+			return nil
+		}
 	}
 	return fmt.Errorf("unknown hook kind %q", hi.Kind)
 }

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -127,6 +128,9 @@ type HookContext struct {
 	// rebootPriority tells us when the hook wants to reboot. If rebootPriority is jujuc.RebootNow
 	// the hook will be killed and requeued
 	rebootPriority jujuc.RebootPriority
+
+	// storageInstances contains the storageInstances associated with a unit,
+	storageInstances []storage.StorageInstance
 }
 
 func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
@@ -186,6 +190,10 @@ func (ctx *HookContext) PrivateAddress() (string, bool) {
 
 func (ctx *HookContext) AvailabilityZone() (string, bool) {
 	return ctx.availabilityzone, ctx.availabilityzone != ""
+}
+
+func (ctx *HookContext) StorageInstances() ([]storage.StorageInstance, bool) {
+	return ctx.storageInstances, len(ctx.storageInstances) > 0
 }
 
 func (ctx *HookContext) OpenPorts(protocol string, fromPort, toPort int) error {

--- a/worker/uniter/runner/context.go
+++ b/worker/uniter/runner/context.go
@@ -131,6 +131,9 @@ type HookContext struct {
 
 	// storageInstances contains the storageInstances associated with a unit,
 	storageInstances []storage.StorageInstance
+
+	// storageId is the id of the storage instance associated with the running hook.
+	storageId string
 }
 
 func (ctx *HookContext) RequestReboot(priority jujuc.RebootPriority) error {
@@ -192,8 +195,17 @@ func (ctx *HookContext) AvailabilityZone() (string, bool) {
 	return ctx.availabilityzone, ctx.availabilityzone != ""
 }
 
-func (ctx *HookContext) StorageInstances() ([]storage.StorageInstance, bool) {
-	return ctx.storageInstances, len(ctx.storageInstances) > 0
+func (ctx *HookContext) HookStorageInstance() (*storage.StorageInstance, bool) {
+	return ctx.StorageInstance(ctx.storageId)
+}
+
+func (ctx *HookContext) StorageInstance(storageId string) (*storage.StorageInstance, bool) {
+	for _, storageInstance := range ctx.storageInstances {
+		if storageInstance.Id == ctx.storageId {
+			return &storageInstance, true
+		}
+	}
+	return nil, false
 }
 
 func (ctx *HookContext) OpenPorts(protocol string, fromPort, toPort int) error {

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -159,6 +159,7 @@ func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
 		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
 	}
 	if hookInfo.Kind.IsStorage() {
+		ctx.storageId = hookInfo.StorageId
 		if err := f.updateStorage(ctx); err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -158,6 +158,11 @@ func (f *factory) NewHookRunner(hookInfo hook.Info) (Runner, error) {
 		}
 		hookName = fmt.Sprintf("%s-%s", relation.Name(), hookInfo.Kind)
 	}
+	if hookInfo.Kind.IsStorage() {
+		if err := f.updateStorage(ctx); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	// Metrics are only sent from the collect-metrics hook.
 	if hookInfo.Kind == hooks.CollectMetrics {
 		ctx.canAddMetrics = true
@@ -233,6 +238,7 @@ func (f *factory) coreContext() (*HookContext, error) {
 		canAddMetrics:      false,
 		definedMetrics:     nil,
 		pendingPorts:       make(map[PortRange]PortRangeInfo),
+		storageInstances:   nil,
 	}
 	if err := f.updateContext(ctx); err != nil {
 		return nil, err
@@ -318,6 +324,11 @@ func (f *factory) updateContext(ctx *HookContext) (err error) {
 		return err
 	}
 	return nil
+}
+
+func (f *factory) updateStorage(ctx *HookContext) (err error) {
+	ctx.storageInstances, err = f.state.StorageInstances(f.unit.Tag())
+	return err
 }
 
 func inferRemoteUnit(rctxs map[int]*ContextRelation, info CommandInfo) (int, string, error) {

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -10,11 +10,16 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/utils/featureflag"
 	"github.com/juju/utils/fs"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4/hooks"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner"
@@ -30,6 +35,8 @@ type FactorySuite struct {
 var _ = gc.Suite(&FactorySuite{})
 
 func (s *FactorySuite) SetUpTest(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	s.HookContextSuite.SetUpTest(c)
 	s.paths = NewRealPaths(c)
 	s.membership = map[int][]string{}
@@ -122,6 +129,18 @@ func (s *FactorySuite) AssertNotActionContext(c *gc.C, ctx runner.Context) {
 	c.Assert(err, gc.ErrorMatches, "not running an action")
 }
 
+func (s *FactorySuite) AssertNotStorageContext(c *gc.C, ctx runner.Context) {
+	storageInstances, ok := ctx.StorageInstances()
+	c.Assert(storageInstances, gc.HasLen, 0)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *FactorySuite) AssertStorageContext(c *gc.C, ctx runner.Context, instances []storage.StorageInstance) {
+	fromCache, ok := ctx.StorageInstances()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(instances, jc.SameContents, fromCache)
+}
+
 func (s *FactorySuite) AssertRelationContext(c *gc.C, ctx runner.Context, relId int, remoteUnit string) *runner.ContextRelation {
 	actualRemoteUnit, _ := ctx.RemoteUnitName()
 	c.Assert(actualRemoteUnit, gc.Equals, remoteUnit)
@@ -145,6 +164,7 @@ func (s *FactorySuite) TestNewCommandRunnerNoRelation(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewCommandRunnerRelationIdDoesNotExist(c *gc.C) {
@@ -203,6 +223,7 @@ func (s *FactorySuite) TestNewCommandRunnerForceNoRemoteUnit(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertRelationContext(c, ctx, 0, "")
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewCommandRunnerForceRemoteUnitMissing(c *gc.C) {
@@ -214,6 +235,7 @@ func (s *FactorySuite) TestNewCommandRunnerForceRemoteUnitMissing(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertRelationContext(c, ctx, 0, "blah/123")
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewCommandRunnerInferRemoteUnit(c *gc.C) {
@@ -225,6 +247,7 @@ func (s *FactorySuite) TestNewCommandRunnerInferRemoteUnit(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertRelationContext(c, ctx, 0, "foo/2")
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewHookRunner(c *gc.C) {
@@ -235,12 +258,52 @@ func (s *FactorySuite) TestNewHookRunner(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewHookRunnerWithBadHook(c *gc.C) {
 	rnr, err := s.factory.NewHookRunner(hook.Info{})
 	c.Assert(rnr, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `unknown hook kind ""`)
+}
+
+func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
+	// We need to set up a unit that has storage metadata defined.
+	ch := s.AddTestingCharm(c, "storage-block")
+	sCons := map[string]state.StorageConstraints{
+		"data": state.StorageConstraints{Pool: "", Size: 1024, Count: 1},
+	}
+	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
+
+	unit := s.AddUnit(c, service)
+	password, err := utils.RandomPassword()
+	err = unit.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	st := s.OpenAPIAs(c, unit.Tag(), password)
+	uniter, err := st.Uniter()
+	c.Assert(err, jc.ErrorIsNil)
+
+	factory, err := runner.NewFactory(
+		uniter,
+		unit.Tag().(names.UnitTag),
+		s.getRelationInfos,
+		s.paths,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rnr, err := factory.NewHookRunner(hook.Info{
+		Kind:       hooks.StorageAttached,
+		StorageIds: []string{"1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AssertPaths(c, rnr)
+	ctx := rnr.Context()
+	c.Assert(ctx.UnitName(), gc.Equals, "storage-block/0")
+	s.AssertStorageContext(c, ctx, []storage.StorageInstance{
+		{Id: "data/0", Kind: storage.StorageKindBlock, Location: ""}},
+	)
+	s.AssertNotActionContext(c, ctx)
+	s.AssertNotRelationContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewHookRunnerWithRelation(c *gc.C) {
@@ -254,6 +317,7 @@ func (s *FactorySuite) TestNewHookRunnerWithRelation(c *gc.C) {
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertRelationContext(c, ctx, 1, "")
+	s.AssertNotStorageContext(c, ctx)
 }
 
 func (s *FactorySuite) TestNewHookRunnerPrunesNonMemberCaches(c *gc.C) {
@@ -310,6 +374,7 @@ func (s *FactorySuite) TestNewHookRunnerRelationJoinedUpdatesRelationContextAndC
 	ctx := rnr.Context()
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
 	rel := s.AssertRelationContext(c, ctx, 1, "r/0")
 	c.Assert(rel.UnitNames(), jc.DeepEquals, []string{"r/0"})
 	cached0, member := s.getCache(1, "r/0")
@@ -335,6 +400,7 @@ func (s *FactorySuite) TestNewHookRunnerRelationChangedUpdatesRelationContextAnd
 	ctx := rnr.Context()
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
 	rel := s.AssertRelationContext(c, ctx, 1, "r/4")
 	c.Assert(rel.UnitNames(), jc.DeepEquals, []string{"r/0", "r/4"})
 	cached0, member := s.getCache(1, "r/0")
@@ -363,6 +429,7 @@ func (s *FactorySuite) TestNewHookRunnerRelationDepartedUpdatesRelationContextAn
 	ctx := rnr.Context()
 	s.AssertCoreContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
+	s.AssertNotStorageContext(c, ctx)
 	rel := s.AssertRelationContext(c, ctx, 1, "r/0")
 	c.Assert(rel.UnitNames(), jc.DeepEquals, []string{"r/4"})
 	cached0, member := s.getCache(1, "r/0")

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -103,7 +103,7 @@ type Context interface {
 	// StorageInstance returns the storage instance with the given id.
 	StorageInstance(storageId string) (*storage.StorageInstance, bool)
 
-	// HookStorageInstance returns the storage instances associated
+	// HookStorageInstance returns the storage instance associated
 	// the executing hook.
 	HookStorageInstance() (*storage.StorageInstance, bool)
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -100,8 +100,12 @@ type Context interface {
 	// RequestReboot will set the reboot flag to true on the machine agent
 	RequestReboot(prio RebootPriority) error
 
-	// StorageInstances returns the storage instances associated with a unit.
-	StorageInstances() ([]storage.StorageInstance, bool)
+	// StorageInstance returns the storage instance with the given id.
+	StorageInstance(storageId string) (*storage.StorageInstance, bool)
+
+	// HookStorageInstance returns the storage instances associated
+	// the executing hook.
+	HookStorageInstance() (*storage.StorageInstance, bool)
 }
 
 // ContextRelation expresses the capabilities of a hook with respect to a relation.

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/storage"
 )
 
 type RebootPriority int
@@ -98,6 +99,9 @@ type Context interface {
 
 	// RequestReboot will set the reboot flag to true on the machine agent
 	RequestReboot(prio RebootPriority) error
+
+	// StorageInstances returns the storage instances associated with a unit.
+	StorageInstances() ([]storage.StorageInstance, bool)
 }
 
 // ContextRelation expresses the capabilities of a hook with respect to a relation.

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/juju/cmd"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/exec"
+	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gnuflag"
 
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -202,11 +204,14 @@ var newCommandTests = []struct {
 	{"relation-list", ""},
 	{"relation-set", ""},
 	{"unit-get", ""},
+	{"storage-get", ""},
 	// The error message contains .exe on Windows
 	{"random", "unknown command: random(.exe)?"},
 }
 
 func (s *NewCommandSuite) TestNewCommand(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 	ctx := s.GetHookContext(c, 0, "")
 	for _, t := range newCommandTests {
 		com, err := jujuc.NewCommand(ctx, cmdString(t.name))

--- a/worker/uniter/runner/jujuc/storage-get.go
+++ b/worker/uniter/runner/jujuc/storage-get.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/storage"
+)
+
+// StorageGetCommand implements the storage-get command.
+type StorageGetCommand struct {
+	cmd.CommandBase
+	ctx                Context
+	storageInstanceIds []string
+	out                cmd.Output
+}
+
+func NewStorageGetCommand(ctx Context) cmd.Command {
+	return &StorageGetCommand{ctx: ctx}
+}
+
+func (c *StorageGetCommand) Info() *cmd.Info {
+	doc := `
+When no <storageInstanceId> is supplied, all storage instances are printed.
+`
+	return &cmd.Info{
+		Name:    "storage-get",
+		Args:    "[<storageInstanceId>]*",
+		Purpose: "print storage information",
+		Doc:     doc,
+	}
+}
+
+func (c *StorageGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+}
+
+func (c *StorageGetCommand) Init(args []string) error {
+	c.storageInstanceIds = args
+	return nil
+}
+
+func wantInstance(storageId string, storageIds []string) bool {
+	for _, id := range storageIds {
+		if id == storageId {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *StorageGetCommand) Run(ctx *cmd.Context) error {
+	storageInstances, ok := c.ctx.StorageInstances()
+	if !ok {
+		return nil
+	}
+	var value []storage.StorageInstance
+	if len(c.storageInstanceIds) > 0 {
+		for _, instance := range storageInstances {
+			if wantInstance(instance.Id, c.storageInstanceIds) {
+				value = append(value, instance)
+			}
+		}
+	} else {
+		value = storageInstances
+	}
+	return c.out.Write(ctx, value)
+}

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -1,0 +1,118 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/featureflag"
+	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v1"
+
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type storageGetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&storageGetSuite{})
+
+func (s *storageGetSuite) SetUpTest(c *gc.C) {
+	s.ContextSuite.SetUpTest(c)
+	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+}
+
+var (
+	blockStorageInstance = storage.StorageInstance{
+		Id:       "1234",
+		Kind:     storage.StorageKindBlock,
+		Location: "/dev/sda",
+	}
+	fileSystemStorageInstance = storage.StorageInstance{
+		Id:       "abcd",
+		Kind:     storage.StorageKindFilesystem,
+		Location: "/mnt/data",
+	}
+)
+
+var storageGetTests = []struct {
+	args   []string
+	format int
+	out    []storage.StorageInstance
+}{
+	{[]string{}, formatYaml, []storage.StorageInstance{blockStorageInstance, fileSystemStorageInstance}},
+	{[]string{"1234"}, formatYaml, []storage.StorageInstance{blockStorageInstance}},
+	{[]string{"--format", "json"}, formatJson, []storage.StorageInstance{blockStorageInstance, fileSystemStorageInstance}},
+	{[]string{"1234", "--format", "json"}, formatJson, []storage.StorageInstance{blockStorageInstance}},
+}
+
+func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
+	for i, t := range storageGetTests {
+		c.Logf("test %d: %#v", i, t.args)
+		hctx := s.GetHookContext(c, -1, "")
+		com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := testing.Context(c)
+		code := cmd.Main(com, ctx, t.args)
+		c.Assert(code, gc.Equals, 0)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+
+		out := []storage.StorageInstance{}
+		switch t.format {
+		case formatYaml:
+			c.Assert(goyaml.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
+		case formatJson:
+			c.Assert(json.Unmarshal(bufferBytes(ctx.Stdout), &out), gc.IsNil)
+		}
+		c.Assert(out, gc.DeepEquals, t.out)
+	}
+}
+
+func (s *storageGetSuite) TestHelp(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--help"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] [<storageInstanceId>]*
+purpose: print storage information
+
+options:
+--format  (= smart)
+    specify output format (json|smart|yaml)
+-o, --output (= "")
+    specify an output file
+
+When no <storageInstanceId> is supplied, all storage instances are printed.
+`)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+}
+
+//
+func (s *storageGetSuite) TestOutputPath(c *gc.C) {
+	hctx := s.GetHookContext(c, -1, "")
+	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := testing.Context(c)
+	code := cmd.Main(com, ctx, []string{"--output", "some-file", "1234"})
+	c.Assert(code, gc.Equals, 0)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
+	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	out := []storage.StorageInstance{}
+	c.Assert(goyaml.Unmarshal(content, &out), gc.IsNil)
+	c.Assert(out, gc.DeepEquals, []storage.StorageInstance{blockStorageInstance})
+}

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -114,18 +114,19 @@ func (c *Context) AvailabilityZone() (string, bool) {
 	return "us-east-1a", true
 }
 
-func (c *Context) StorageInstances() ([]storage.StorageInstance, bool) {
-	return []storage.StorageInstance{
-		{
-			"1234",
-			storage.StorageKindBlock,
-			"/dev/sda",
-		},
-		{
-			"abcd",
-			storage.StorageKindFilesystem,
-			"/mnt/data",
-		},
+func (c *Context) StorageInstance(storageId string) (*storage.StorageInstance, bool) {
+	return &storage.StorageInstance{
+		"1234",
+		storage.StorageKindBlock,
+		"/dev/sda",
+	}, true
+}
+
+func (c *Context) HookStorageInstance() (*storage.StorageInstance, bool) {
+	return &storage.StorageInstance{
+		"1234",
+		storage.StorageKindBlock,
+		"/dev/sda",
 	}, true
 }
 

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -111,6 +112,21 @@ func (c *Context) PrivateAddress() (string, bool) {
 
 func (c *Context) AvailabilityZone() (string, bool) {
 	return "us-east-1a", true
+}
+
+func (c *Context) StorageInstances() ([]storage.StorageInstance, bool) {
+	return []storage.StorageInstance{
+		{
+			"1234",
+			storage.StorageKindBlock,
+			"/dev/sda",
+		},
+		{
+			"abcd",
+			storage.StorageKindFilesystem,
+			"/mnt/data",
+		},
+	}, true
 }
 
 func (c *Context) OpenPorts(protocol string, fromPort, toPort int) error {


### PR DESCRIPTION

Introduce infrastructure for a storage-get hook tool.
There's now storage api functionality in diskformatter and uniter facades. We should consider pulling this out into a common facade as the implementation progresses.

A new V2 uniter facade is introduced to provide the new storage apis via an embedded storage facade.