### PR TITLE
Add support for default pools for env providers

### DIFF
--- a/provider/all/all.go
+++ b/provider/all/all.go
@@ -3,8 +3,8 @@
 
 package all
 
-// Register all the available providers.
 import (
+	// Register all the available providers.
 	_ "github.com/juju/juju/provider/azure"
 	_ "github.com/juju/juju/provider/ec2"
 	_ "github.com/juju/juju/provider/joyent"
@@ -12,4 +12,7 @@ import (
 	_ "github.com/juju/juju/provider/maas"
 	_ "github.com/juju/juju/provider/manual"
 	_ "github.com/juju/juju/provider/openstack"
+
+	// Register provider storage.
+	_ "github.com/juju/juju/provider/ec2/storage"
 )

--- a/provider/ec2/storage/ebs.go
+++ b/provider/ec2/storage/ebs.go
@@ -15,7 +15,12 @@ import (
 //TODO - add tests
 
 const (
+	// Provider types.
 	EBSProviderType = storage.ProviderType("ebs")
+
+	// OOTB Storage pools.
+	EBSPool    = "ebs"
+	EBSSSDPool = "ebs-ssd"
 
 	// Config attributes
 

--- a/provider/ec2/storage/init.go
+++ b/provider/ec2/storage/init.go
@@ -14,4 +14,6 @@ func init() {
 	storage.RegisterProvider(EBSProviderType, &ebsProvider{})
 	storage.RegisterEnvironStorageProviders("ec2", EBSProviderType)
 	storage.RegisterEnvironStorageProviders("ec2", provider.LoopProviderType)
+
+	storage.RegisterDefaultPool("ec2", storage.StorageKindBlock, EBSPool)
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -413,22 +413,20 @@ func validateStorageConstraints(st *State, cons map[string]StorageConstraints, c
 				)
 			}
 		}
-		if cons.Pool != "" {
-			// Ensure the pool type is supported by the environment.
-			pm := pool.NewPoolManager(NewStateSettings(st))
-			p, err := pm.Get(cons.Pool)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			providerType := p.Type()
-			if !storage.IsProviderSupported(envType, providerType) {
-				return errors.Errorf(
-					"pool %q uses storage provider %q which is not supported for environments of type %q",
-					cons.Pool,
-					providerType,
-					envType,
-				)
-			}
+		// Ensure the pool type is supported by the environment.
+		pm := pool.NewPoolManager(NewStateSettings(st))
+		p, err := pm.Get(cons.Pool)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		providerType := p.Type()
+		if !storage.IsProviderSupported(envType, providerType) {
+			return errors.Errorf(
+				"pool %q uses storage provider %q which is not supported for environments of type %q",
+				cons.Pool,
+				providerType,
+				envType,
+			)
 		}
 		if cons.Count < uint64(charmStorage.CountMin) {
 			return errors.Errorf(

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/pool"
+	"github.com/juju/juju/storage/provider"
 )
 
 type StorageStateSuite struct {
@@ -24,6 +27,12 @@ func (s *StorageStateSuite) SetUpTest(c *gc.C) {
 	// This suite is all about storage, so enable the feature by default.
 	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
+
+	// Create a default pool for block devices.
+	pm := pool.NewPoolManager(state.NewStateSettings(s.State))
+	_, err := pm.Create("block", provider.LoopProviderType, map[string]interface{}{})
+	c.Assert(err, jc.ErrorIsNil)
+	storage.RegisterEnvironStorageProviders("someprovider", provider.LoopProviderType)
 }
 
 func makeStorageCons(pool string, size, count uint64) state.StorageConstraints {
@@ -55,22 +64,25 @@ func (s *StorageStateSuite) TestAddServiceStorageConstraints(c *gc.C) {
 	}
 	assertErr(nil, `.*no constraints specified for store.*`)
 
-	storage := map[string]state.StorageConstraints{
+	storageCons := map[string]state.StorageConstraints{
 		"multi1to10": makeStorageCons("", 1024, 1),
 		"multi2up":   makeStorageCons("", 1024, 1),
 	}
-	assertErr(storage, `cannot add service "storage-block2": charm "storage-block2" store "multi2up": 2 instances required, 1 specified`)
-	storage["multi2up"] = makeStorageCons("", 1024, 2)
-	storage["multi1to10"] = makeStorageCons("", 1024, 11)
-	assertErr(storage, `cannot add service "storage-block2": charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified`)
-	storage["multi1to10"] = makeStorageCons("ebs", 1024, 10)
-	assertErr(storage, `cannot add service "storage-block2": reading pool "ebs": settings not found`)
-	storage["multi1to10"] = makeStorageCons("", 1024, 10)
-	_, err := addService(storage)
+	assertErr(storageCons, `cannot add service "storage-block2": no storage pool specifed and no default available for storage kind "block" .*`)
+	storage.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "block")
+	assertErr(storageCons, `cannot add service "storage-block2": charm "storage-block2" store "multi2up": 2 instances required, 1 specified`)
+	storageCons["multi2up"] = makeStorageCons("", 1024, 2)
+	storageCons["multi1to10"] = makeStorageCons("", 1024, 11)
+	assertErr(storageCons, `cannot add service "storage-block2": charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified`)
+	storageCons["multi1to10"] = makeStorageCons("ebs", 1024, 10)
+	assertErr(storageCons, `cannot add service "storage-block2": reading pool "ebs": settings not found`)
+	storageCons["multi1to10"] = makeStorageCons("", 1024, 10)
+	_, err := addService(storageCons)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
+	storage.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "block")
 	// Each unit added to the service will create storage instances
 	// to satisfy the service's storage constraints.
 	ch := s.AddTestingCharm(c, "storage-block2")
@@ -97,6 +109,7 @@ func (s *StorageStateSuite) TestAddUnit(c *gc.C) {
 }
 
 func (s *StorageStateSuite) TestRemoveUnit(c *gc.C) {
+	storage.RegisterDefaultPool("someprovider", storage.StorageKindBlock, "block")
 	ch := s.AddTestingCharm(c, "storage-block")
 	storage := map[string]state.StorageConstraints{
 		"data": makeStorageCons("", 1024, 1),

--- a/storage/provider/init.go
+++ b/storage/provider/init.go
@@ -9,4 +9,6 @@ import (
 
 func init() {
 	storage.RegisterProvider(LoopProviderType, &loopProvider{})
+
+	storage.RegisterDefaultPool("local", storage.StorageKindBlock, LoopPool)
 }

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -19,6 +19,9 @@ const (
 	LoopProviderType     = storage.ProviderType("loop")
 	HostLoopProviderType = storage.ProviderType("hostloop")
 
+	// OOTB Storage pools.
+	LoopPool = "loop"
+
 	// Config attributes
 	LoopDataDir = "data-dir" // top level directory where loop devices are created.
 	LoopSubDir  = "sub-dir"  // optional subdirectory for loop devices.

--- a/storage/providerregistry.go
+++ b/storage/providerregistry.go
@@ -69,3 +69,25 @@ func IsProviderSupported(envType string, providerType ProviderType) bool {
 	}
 	return false
 }
+
+type defaultStoragePool map[StorageKind]string
+
+// defaultPools records the default block and filesystem pools to be
+// used for an environment, if none is specified by the user when deploying.
+var defaultPools map[string]defaultStoragePool = make(map[string]defaultStoragePool)
+
+// RegisterDefaultPool records the default pool for the storage kind and environment.
+// NOTE: the pool is not validated as to whether it exists, or if its type is
+// supported by the environment. This is expected to be done by the caller.
+func RegisterDefaultPool(envType string, kind StorageKind, pool string) {
+	if _, ok := defaultPools[envType]; !ok {
+		defaultPools[envType] = make(defaultStoragePool)
+	}
+	defaultPools[envType][kind] = pool
+}
+
+// DefaultPool returns the default storage pool for the storage kind and environment.
+func DefaultPool(envType string, kind StorageKind) (string, bool) {
+	pool, ok := defaultPools[envType][kind]
+	return pool, ok
+}

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -74,14 +74,18 @@ func (s *providerRegistrySuite) TestRegisterEnvironProvidersMultipleCalls(c *gc.
 	c.Assert(storage.IsProviderSupported("ec2", ptypeBar), jc.IsTrue)
 }
 
-func (s *providerRegistrySuite) DefaultProviderForEnviron(c *gc.C) {
-	ptypeFoo := storage.ProviderType("foo")
-	ptypeBar := storage.ProviderType("bar")
-	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
-}
-
-func (s *providerRegistrySuite) NoDefaultProviderForEnviron(c *gc.C) {
-	ptypeFoo := storage.ProviderType("foo")
-	ptypeBar := storage.ProviderType("bar")
-	storage.RegisterEnvironStorageProviders("ec2", ptypeFoo, ptypeBar)
+func (s *providerRegistrySuite) TestDefaultPool(c *gc.C) {
+	storage.RegisterDefaultPool("ec2", storage.StorageKindBlock, "ebs")
+	storage.RegisterDefaultPool("ec2", storage.StorageKindFilesystem, "nfs")
+	storage.RegisterDefaultPool("local", storage.StorageKindFilesystem, "nfs")
+	pool, ok := storage.DefaultPool("ec2", storage.StorageKindBlock)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(pool, gc.Equals, "ebs")
+	pool, ok = storage.DefaultPool("ec2", storage.StorageKindFilesystem)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(pool, gc.Equals, "nfs")
+	pool, ok = storage.DefaultPool("local", storage.StorageKindBlock)
+	c.Assert(ok, jc.IsFalse)
+	pool, ok = storage.DefaultPool("maas", storage.StorageKindBlock)
+	c.Assert(ok, jc.IsFalse)
 }

--- a/upgrades/storage.go
+++ b/upgrades/storage.go
@@ -21,8 +21,8 @@ var defaultLoopPools = map[string]map[string]interface{}{
 }
 
 var defaultEBSPools = map[string]map[string]interface{}{
-	"ebs":     map[string]interface{}{},
-	"ebs-ssd": map[string]interface{}{"volume-type": "gp2"},
+	ec2storage.EBSPool:    map[string]interface{}{},
+	ec2storage.EBSSSDPool: map[string]interface{}{"volume-type": "gp2"},
 }
 
 func addDefaultStoragePools(st *state.State, agentConfig agent.Config) error {


### PR DESCRIPTION
There's now a registry of default pools for environment types.
If storage is specified without a pool, the default is used.