### PR TITLE
Quick fix for adding default pools on startup, and account for VolumeTypeNotAvailableInZone errors

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -55,6 +55,7 @@ import (
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -896,6 +897,14 @@ func (a *MachineAgent) StateWorker() (worker.Worker, error) {
 			a.startWorkerAfterUpgrade(runner, "lease manager", func() (worker.Worker, error) {
 				workerLoop := lease.WorkerLoop(st)
 				return worker.NewSimpleWorker(workerLoop), nil
+			})
+			// TODO - we do this here because upgrade no longer handle new installs.
+			// Fix this once we sort out what to do.
+			a.startWorkerAfterUpgrade(runner, "storage pools", func() (worker.Worker, error) {
+				addDefaultPools := func(_ <-chan struct{}) error {
+					return upgrades.AddDefaultStoragePools(st, agentConfig)
+				}
+				return worker.NewSimpleWorker(addDefaultPools), nil
 			})
 			certChangedChan := make(chan params.StateServingInfo, 1)
 			runner.StartWorker("apiserver", a.apiserverWorkerStarter(st, certChangedChan))

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1241,7 +1241,10 @@ func isZoneConstrainedError(err error) bool {
 			// if the AZ does not have a default subnet. Until we have proper
 			// support for networks, we'll skip over these.
 			return strings.HasPrefix(err.Message, "No default subnet for availability zone")
+		case "VolumeTypeNotAvailableInZone":
+			return true
 		}
+
 	}
 	return false
 }

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -477,6 +477,11 @@ var azConstrainedErr = &amzec2.Error{
 	Message: "The requested Availability Zone is currently constrained etc.",
 }
 
+var azVolumeTypeNotAvailableInZoneErr = &amzec2.Error{
+	Code:    "VolumeTypeNotAvailableInZone",
+	Message: "blah blah",
+}
+
 var azInsufficientInstanceCapacityErr = &amzec2.Error{
 	Code: "InsufficientInstanceCapacity",
 	Message: "We currently do not have sufficient m1.small capacity in the " +
@@ -493,6 +498,10 @@ var azNoDefaultSubnetErr = &amzec2.Error{
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllConstrained(c *gc.C) {
 	t.testStartInstanceAvailZoneAllConstrained(c, azConstrainedErr)
+}
+
+func (t *localServerSuite) TestStartInstanceVolumeTypeNotAvailable(c *gc.C) {
+	t.testStartInstanceAvailZoneAllConstrained(c, azVolumeTypeNotAvailableInZoneErr)
 }
 
 func (t *localServerSuite) TestStartInstanceAvailZoneAllInsufficientInstanceCapacity(c *gc.C) {

--- a/upgrades/export_test.go
+++ b/upgrades/export_test.go
@@ -40,5 +40,5 @@ var (
 
 	// 123 upgrade functions
 	AddEnvironmentUUIDToAgentConfig = addEnvironmentUUIDToAgentConfig
-	AddDefaultStoragePools          = addDefaultStoragePools
+	EnsureStorage                   = ensureStorage
 )

--- a/upgrades/steps123.go
+++ b/upgrades/steps123.go
@@ -19,7 +19,7 @@ func stateStepsFor123() []Step {
 				description: "add default storage pools",
 				targets:     []Target{DatabaseMaster},
 				run: func(context Context) error {
-					return addDefaultStoragePools(context.State(), context.AgentConfig())
+					return ensureStorage(context.State(), context.AgentConfig())
 				},
 			},
 		}

--- a/upgrades/storage.go
+++ b/upgrades/storage.go
@@ -25,7 +25,11 @@ var defaultEBSPools = map[string]map[string]interface{}{
 	ec2storage.EBSSSDPool: map[string]interface{}{"volume-type": "gp2"},
 }
 
-func addDefaultStoragePools(st *state.State, agentConfig agent.Config) error {
+var ensureStorage = AddDefaultStoragePools
+
+// TODO - only exported so we can call from machine agent pending agreeing
+// on how to solve change in upgrade behaviour.
+func AddDefaultStoragePools(st *state.State, agentConfig agent.Config) error {
 	settings := state.NewStateSettings(st)
 	pm := pool.NewPoolManager(settings)
 

--- a/upgrades/storage_test.go
+++ b/upgrades/storage_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&defaultStoragePoolsSuite{})
 func (s *defaultStoragePoolsSuite) TestDefaultStoragePools(c *gc.C) {
 	s.PatchEnvironment(osenv.JujuFeatureFlagEnvKey, "storage")
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
-	err := upgrades.AddDefaultStoragePools(s.State, &mockAgentConfig{dataDir: s.DataDir()})
+	err := upgrades.EnsureStorage(s.State, &mockAgentConfig{dataDir: s.DataDir()})
 	c.Assert(err, jc.ErrorIsNil)
 	settings := state.NewStateSettings(s.State)
 	pm := pool.NewPoolManager(settings)


### PR DESCRIPTION
Upgrades now don't run if deploying a fresh install, so work around that to create default pools.

Account for the fact that not all EBS instances are available in every zone.

Tested live on AWS. Could deploy to ebs and ebs-ssd pools.
storage-attached hook works also.