### PR TITLE
Moar storage-attached

### DIFF
--- a/api/diskformatter/diskformatter.go
+++ b/api/diskformatter/diskformatter.go
@@ -88,3 +88,22 @@ func (st *State) BlockDeviceStorageInstances(tags []names.DiskTag) (params.Stora
 	}
 	return results, nil
 }
+
+func (st *State) SetMountPoints(mountPoints map[names.StorageTag]string) (params.ErrorResults, error) {
+	var results params.ErrorResults
+	args := params.StorageMountPoints{
+		StorageMountPoints: make([]params.StorageMountPoint, 0, len(mountPoints)),
+	}
+	for tag, mountPoint := range mountPoints {
+		arg := params.StorageMountPoint{tag.String(), mountPoint}
+		args.StorageMountPoints = append(args.StorageMountPoints, arg)
+	}
+	err := st.facade.FacadeCall("SetMountPoints", args, &results)
+	if err != nil {
+		return params.ErrorResults{}, err
+	}
+	if len(results.Results) != len(mountPoints) {
+		panic(errors.Errorf("expected %d results, got %d", len(mountPoints), len(results.Results)))
+	}
+	return results, nil
+}

--- a/api/uniter/storage_test.go
+++ b/api/uniter/storage_test.go
@@ -49,7 +49,7 @@ func (s *storageSuite) TestStorageInstances(c *gc.C) {
 	})
 
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	instances, err := st.StorageInstances(names.NewUnitTag("mysql/0"))
+	instances, err := st.UnitStorageInstances(names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
 	c.Assert(instances, gc.DeepEquals, storageInstances[0].Instances)
@@ -63,7 +63,7 @@ func (s *storageSuite) TestStorageInstanceResultCountMismatch(c *gc.C) {
 		return nil
 	})
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	c.Assert(func() { st.StorageInstances(names.NewUnitTag("mysql/0")) }, gc.PanicMatches, "expected 1 result, got 2")
+	c.Assert(func() { st.UnitStorageInstances(names.NewUnitTag("mysql/0")) }, gc.PanicMatches, "expected 1 result, got 2")
 }
 
 func (s *storageSuite) TestAPIErrors(c *gc.C) {
@@ -71,6 +71,6 @@ func (s *storageSuite) TestAPIErrors(c *gc.C) {
 		return errors.New("bad")
 	})
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	_, err := st.StorageInstances(names.NewUnitTag("mysql/0"))
+	_, err := st.UnitStorageInstances(names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "bad")
 }

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -223,10 +223,20 @@ func storageStorageInstance(st state.StorageInstance) (storage.StorageInstance, 
 	if st == nil {
 		return storage.StorageInstance{}, nil
 	}
+	var actualLocation string
+	var requestedLocation string
+	info, err := st.Info()
+	if err == nil {
+		actualLocation = info.Location
+	}
+	if params, ok := st.Params(); ok {
+		requestedLocation = params.Location
+	}
 	return storage.StorageInstance{
 		st.Id(),
 		storageStorageKind(st.Kind()),
-		"", // TODO(wallyworld) Location
+		actualLocation,
+		requestedLocation,
 	}, nil
 }
 

--- a/apiserver/diskformatter/state.go
+++ b/apiserver/diskformatter/state.go
@@ -14,6 +14,7 @@ type stateInterface interface {
 	WatchUnitMachineBlockDevices(names.UnitTag) (watcher.StringsWatcher, error)
 	BlockDevice(name string) (state.BlockDevice, error)
 	StorageInstance(id string) (state.StorageInstance, error)
+	SetStorageInstanceInfo(id string, info state.StorageInstanceInfo) error
 }
 
 var getState = func(st *state.State) stateInterface {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -858,3 +858,12 @@ type UnitStorageInstances struct {
 type UnitStorageInstancesResults struct {
 	UnitsStorageInstances []UnitStorageInstances `json:"unitstorageinstances,omitempty"`
 }
+
+type StorageMountPoint struct {
+	StorageTag string `json:"storage"`
+	MountPoint string `json:"mountpoint"`
+}
+
+type StorageMountPoints struct {
+	StorageMountPoints []StorageMountPoint `json:"storagemountpoints"`
+}

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -78,6 +78,7 @@ func (s *StorageAPI) getOneUnitStorageInstances(canAccess common.AuthFunc, unitT
 			stateStorageInstance.Id(),
 			storage.StorageKind(stateStorageInstance.Kind()),
 			info.Location,
+			"",
 		}
 		result.Instances = append(result.Instances, storageInstance)
 	}
@@ -118,5 +119,6 @@ func (s *StorageAPI) getOneStorageInstance(canAccess common.AuthFunc, tag string
 		stateStorageInstance.Id(),
 		storage.StorageKind(stateStorageInstance.Kind()),
 		info.Location,
+		"",
 	}, nil
 }

--- a/apiserver/uniter/storage.go
+++ b/apiserver/uniter/storage.go
@@ -68,10 +68,16 @@ func (s *StorageAPI) getOneUnitStorageInstances(canAccess common.AuthFunc, unitT
 			result.Instances = nil
 			break
 		}
+		info, err := stateStorageInstance.Info()
+		if err != nil {
+			result.Error = common.ServerError(err)
+			result.Instances = nil
+			break
+		}
 		storageInstance := storage.StorageInstance{
 			stateStorageInstance.Id(),
 			storage.StorageKind(stateStorageInstance.Kind()),
-			"", //TODO - add Location
+			info.Location,
 		}
 		result.Instances = append(result.Instances, storageInstance)
 	}

--- a/apiserver/uniter/uniter_v2_test.go
+++ b/apiserver/uniter/uniter_v2_test.go
@@ -34,7 +34,7 @@ func (s *uniterV2Suite) SetUpTest(c *gc.C) {
 	s.uniter = uniterAPIV2
 }
 
-func (s *uniterV2Suite) TestStorageInstances(c *gc.C) {
+func (s *uniterV2Suite) TestUnitStorageInstances(c *gc.C) {
 	// We need to set up a unit that has storage metadata defined.
 	ch := s.AddTestingCharm(c, "storage-block")
 	sCons := map[string]state.StorageConstraints{
@@ -46,15 +46,23 @@ func (s *uniterV2Suite) TestStorageInstances(c *gc.C) {
 		Service: service,
 	})
 
+	storageIds, err := unit.StorageInstances()
+	c.Assert(err, gc.IsNil)
+	c.Assert(storageIds, gc.HasLen, 1)
+	err = s.State.SetStorageInstanceInfo(storageIds[0].Id(), state.StorageInstanceInfo{
+		Location: "rightbehindyou",
+	})
+	c.Assert(err, gc.IsNil)
+
 	password, err := utils.RandomPassword()
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
 	uniter, err := st.Uniter()
 	c.Assert(err, jc.ErrorIsNil)
-	instances, err := uniter.StorageInstances(unit.Tag())
+	instances, err := uniter.UnitStorageInstances(unit.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instances, gc.DeepEquals, []storage.StorageInstance{
-		{Id: "data/0", Kind: storage.StorageKindBlock, Location: ""},
+		{Id: "data/0", Kind: storage.StorageKindBlock, Location: "rightbehindyou"},
 	})
 }

--- a/cmd/jujud/unit.go
+++ b/cmd/jujud/unit.go
@@ -196,7 +196,8 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 			if err != nil {
 				return nil, err
 			}
-			return diskformatter.NewWorker(api), nil
+			storageDir := filepath.Join(dataDir, "storage")
+			return diskformatter.NewWorker(storageDir, api), nil
 		})
 	}
 	return cmdutil.NewCloseWorker(logger, runner, st), nil

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -306,6 +306,32 @@ func setProvisionedBlockDeviceInfo(st *State, machineId string, blockDevices map
 				{"$unset", bson.D{{"params", nil}}},
 			},
 		})
+		// TODO(axw) nasty hack, don't do this IRL. This updates the
+		// StorageInstanceInfo when we've created the volume that
+		// backs it.
+		dev, err := st.BlockDevice(name)
+		if err != nil {
+			return err
+		}
+		storageId, ok := dev.StorageInstance()
+		if ok {
+			storageInstanceInfo := &StorageInstanceInfo{
+				// Especially not this.
+				Location: "/dev/" + info.DeviceName,
+			}
+			ops = append(ops, txn.Op{
+				C:  storageInstancesC,
+				Id: storageId,
+				Assert: bson.D{
+					{"info", bson.D{{"$exists", false}}},
+					{"params", bson.D{{"$exists", true}}},
+				},
+				Update: bson.D{
+					{"$set", bson.D{{"info", &storageInstanceInfo}}},
+					{"$unset", bson.D{{"params", nil}}},
+				},
+			})
+		}
 	}
 	if err := st.runTransaction(ops); err != nil {
 		return errors.Errorf("cannot set provisioned block device info: already provisioned")

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -899,7 +899,7 @@ func (s *MachineSuite) TestMachineSetInstanceInfoFailureDoesNotProvision(c *gc.C
 
 	invalidBlockDevices := map[string]state.BlockDeviceInfo{"1065": state.BlockDeviceInfo{}}
 	err = s.machine.SetInstanceInfo("umbrella/0", "fake_nonce", nil, nil, nil, invalidBlockDevices)
-	c.Assert(err, gc.ErrorMatches, "cannot set provisioned block device info: already provisioned")
+	c.Assert(err, gc.ErrorMatches, `block device "1065" not found`)
 	assertNotProvisioned()
 
 	// Create a disk associated with a different machine, and ensure that trying

--- a/state/storage.go
+++ b/state/storage.go
@@ -203,6 +203,22 @@ func (st *State) StorageInstance(id string) (StorageInstance, error) {
 	return &s, nil
 }
 
+func (st *State) SetStorageInstanceInfo(storageId string, info StorageInstanceInfo) error {
+	ops := []txn.Op{{
+		C:  storageInstancesC,
+		Id: storageId,
+		Assert: bson.D{
+			{"info", bson.D{{"$exists", false}}},
+			{"params", bson.D{{"$exists", true}}},
+		},
+		Update: bson.D{
+			{"$set", bson.D{{"info", &info}}},
+			{"$unset", bson.D{{"params", nil}}},
+		},
+	}}
+	return st.runTransaction(ops)
+}
+
 func createStorageInstanceOps(
 	st *State,
 	ownerTag names.Tag,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -35,4 +35,6 @@ type StorageInstance struct {
 
 	// Location is the location relevant to the datastore (block device, filesystem).
 	Location string `yaml:"location" json:"location"`
+
+	RequestedLocation string `yaml:"requested-location" json:"requested-location"`
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -36,5 +36,8 @@ type StorageInstance struct {
 	// Location is the location relevant to the datastore (block device, filesystem).
 	Location string `yaml:"location" json:"location"`
 
+	// RequestedLocation is the desired location specified by the charm.
+	// TODO(axw) this needs to go when we redo the model; this should go
+	// on FilesystemParams.
 	RequestedLocation string `yaml:"requested-location" json:"requested-location"`
 }

--- a/worker/diskformatter/diskformatter.go
+++ b/worker/diskformatter/diskformatter.go
@@ -107,7 +107,7 @@ func (f *diskFormatter) Handle(diskNames []string) error {
 		if storageInstance.Location != "" {
 			// TODO(axw) we need to ensure the mount point
 			// is still there, and remount if needed.
-			logger.Debugf("storage instance %q is already mounted at %q", storageInstance.Location)
+			logger.Debugf("storage instance %q is already mounted at %q", storageInstance.Id, storageInstance.Location)
 			continue
 		}
 		devicePath, err := storage.BlockDevicePath(blockDevices[i])
@@ -122,8 +122,11 @@ func (f *diskFormatter) Handle(diskNames []string) error {
 			}
 		}
 		// Mount the block device and set the location.
-		// TODO(axw) use the location in the charm if specified.
-		location := filepath.Join(f.storageDir, filepath.FromSlash(storageInstance.Id))
+		// TODO(axw) vet requested location?
+		location := storageInstance.RequestedLocation
+		if location == "" {
+			location = filepath.Join(f.storageDir, filepath.FromSlash(storageInstance.Id))
+		}
 		if err := mount(devicePath, location); err != nil {
 			logger.Errorf("failed to mount block device %q: %v", blockDevices[i].Name, err)
 			continue

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -106,7 +106,6 @@ func (st State) validate() (err error) {
 	hasHook := st.Hook != nil
 	hasActionId := st.ActionId != nil
 	hasCharm := st.CharmURL != nil
-	hasStorage := st.StorageIds != nil
 	switch st.Kind {
 	case Install:
 		if hasHook {
@@ -128,9 +127,6 @@ func (st State) validate() (err error) {
 			return errors.New("missing action id")
 		}
 	case StorageChanged:
-		if !hasStorage {
-			return errors.New("missing storage ids")
-		}
 	case RunHook:
 		if hasActionId {
 			return errors.New("unexpected action id")

--- a/worker/uniter/runner/factory.go
+++ b/worker/uniter/runner/factory.go
@@ -328,7 +328,7 @@ func (f *factory) updateContext(ctx *HookContext) (err error) {
 }
 
 func (f *factory) updateStorage(ctx *HookContext) (err error) {
-	ctx.storageInstances, err = f.state.StorageInstances(f.unit.Tag())
+	ctx.storageInstances, err = f.state.UnitStorageInstances(f.unit.Tag())
 	return err
 }
 

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -276,6 +276,14 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	service := s.AddTestingServiceWithStorage(c, "storage-block", ch, sCons)
 
 	unit := s.AddUnit(c, service)
+	storageInstances, err := unit.StorageInstances()
+	c.Assert(err, gc.IsNil)
+	c.Assert(storageInstances, gc.HasLen, 1)
+	err = s.State.SetStorageInstanceInfo(storageInstances[0].Id(), state.StorageInstanceInfo{
+		Location: "rightbehindyou",
+	})
+	c.Assert(err, gc.IsNil)
+
 	password, err := utils.RandomPassword()
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
@@ -302,7 +310,9 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	ctx := rnr.Context()
 	c.Assert(ctx.UnitName(), gc.Equals, "storage-block/0")
 	s.AssertStorageContext(c, ctx, storage.StorageInstance{
-		Id: "data/0", Kind: storage.StorageKindBlock, Location: ""},
+		Id:       "data/0",
+		Kind:     storage.StorageKindBlock,
+		Location: "rightbehindyou"},
 	)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -185,3 +185,37 @@ func (v *relationIdValue) Set(value string) error {
 	v.value = value
 	return nil
 }
+
+// newStorageIdValue returns a gnuflag.Value for convenient parsing of storage
+// ids in ctx.
+func newStorageIdValue(ctx Context, result *string) *storageIdValue {
+	v := &storageIdValue{result: result, ctx: ctx}
+	id := ""
+	if s, found := ctx.HookStorageInstance(); found {
+		id = s.Id
+	}
+	*result = id
+	return v
+}
+
+// storageIdValue implements gnuflag.Value for use in storage commands.
+type storageIdValue struct {
+	result *string
+	ctx    Context
+}
+
+// String returns the current value.
+func (v *storageIdValue) String() string {
+	return *v.result
+}
+
+// Set interprets value as a storage id, if possible, and returns an error
+// if it is not known to the system. The parsed storage id will be written
+// to v.result.
+func (v *storageIdValue) Set(value string) error {
+	if _, found := v.ctx.StorageInstance(value); !found {
+		return fmt.Errorf("unknown storage id")
+	}
+	*v.result = value
+	return nil
+}

--- a/worker/uniter/runner/jujuc/storage-get.go
+++ b/worker/uniter/runner/jujuc/storage-get.go
@@ -28,7 +28,7 @@ When no <key> is supplied, all keys values are printed.
 `
 	return &cmd.Info{
 		Name:    "storage-get",
-		Args:    "<key> [<key>]*",
+		Args:    "[<key>]",
 		Purpose: "print information for storage instance with specified id",
 		Doc:     doc,
 	}
@@ -58,7 +58,7 @@ func (c *StorageGetCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 	values := map[string]interface{}{
-		"kind":     storageInstance.Kind,
+		"kind":     storageInstance.Kind.String(),
 		"location": storageInstance.Location,
 	}
 	if c.key == "" {

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -32,7 +32,10 @@ func (s *storageGetSuite) SetUpTest(c *gc.C) {
 }
 
 var (
-	storageLocation = map[string]interface{}{"location": "/dev/sda"}
+	storageAttributes = map[string]interface{}{
+		"location": "/dev/sda",
+		"kind":     "block",
+	}
 )
 
 var storageGetTests = []struct {
@@ -40,10 +43,10 @@ var storageGetTests = []struct {
 	format int
 	out    interface{}
 }{
-	{[]string{"1234", "location", "--format", "yaml"}, formatYaml, storageLocation},
-	{[]string{"1234", "location", "--format", "json"}, formatJson, storageLocation},
-	{[]string{"1234", "location", "kind"}, -1, "kind: 1\nlocation: /dev/sda\n"},
-	{[]string{"1234", "location"}, -1, "/dev/sda\n"},
+	{[]string{"--format", "yaml"}, formatYaml, storageAttributes},
+	{[]string{"--format", "json"}, formatJson, storageAttributes},
+	{[]string{}, formatYaml, storageAttributes},
+	{[]string{"location"}, -1, "/dev/sda\n"},
 }
 
 func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
@@ -80,7 +83,7 @@ func (s *storageGetSuite) TestHelp(c *gc.C) {
 	ctx := testing.Context(c)
 	code := cmd.Main(com, ctx, []string{"--help"})
 	c.Assert(code, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] <storageInstanceId> <key> [<key>]*
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `usage: storage-get [options] [<key>]
 purpose: print information for storage instance with specified id
 
 options:
@@ -88,6 +91,8 @@ options:
     specify output format (json|smart|yaml)
 -o, --output (= "")
     specify an output file
+-s  (= 1234)
+    specify a storage instance by id
 
 When no <key> is supplied, all keys values are printed.
 `)
@@ -100,7 +105,7 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("storage-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := testing.Context(c)
-	code := cmd.Main(com, ctx, []string{"--format", "yaml", "--output", "some-file", "1234", "location"})
+	code := cmd.Main(com, ctx, []string{"--format", "yaml", "--output", "some-file", "-s", "1234"})
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
@@ -109,5 +114,5 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 
 	var out map[string]interface{}
 	c.Assert(goyaml.Unmarshal(content, &out), gc.IsNil)
-	c.Assert(out, gc.DeepEquals, storageLocation)
+	c.Assert(out, gc.DeepEquals, storageAttributes)
 }

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -119,6 +119,7 @@ func (c *Context) StorageInstance(storageId string) (*storage.StorageInstance, b
 		"1234",
 		storage.StorageKindBlock,
 		"/dev/sda",
+		"location",
 	}, true
 }
 
@@ -127,6 +128,7 @@ func (c *Context) HookStorageInstance() (*storage.StorageInstance, bool) {
 		"1234",
 		storage.StorageKindBlock,
 		"/dev/sda",
+		"location",
 	}, true
 }
 


### PR DESCRIPTION
- Fixes to uniter StorageChanged operation
- Made storage-get more like relation-get:
    * you can specify a storage ID with "-s",
      and it defaults to the hook storage instance.
    * you can specify at most one key. If none
      are specified, you get a map; if one is
      specified you just get that attribute's value.
- When a machine is provisioned, we set the location for associated "block" type storage instances to the device paths.
- When a disk is formatted, we mount it and then set the location on the associated storage instance.