### PR TITLE
cmd/juju/storage: add "list", tweak "show"

### DIFF
--- a/api/storage/client.go
+++ b/api/storage/client.go
@@ -48,3 +48,11 @@ func (c *Client) Show(tags []names.StorageTag) ([]params.StorageInstance, error)
 	}
 	return all, allErr.Combine()
 }
+
+func (c *Client) List() ([]params.StorageInstance, error) {
+	result := params.StorageListResult{}
+	if err := c.facade.FacadeCall("List", nil, &result); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result.Instances, nil
+}

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -5,12 +5,15 @@ package params
 
 // StorageInstance holds data for a storage instance.
 type StorageInstance struct {
-	StorageTag    string
-	OwnerTag      string
-	Location      string
-	StorageName   string
-	AvailableSize uint64
-	TotalSize     uint64
+	StorageTag string
+	OwnerTag   string
+
+	// Using pointers below to make values nullable.
+	// Nil values are unknown/unavailable.
+
+	Location      *string
+	AvailableSize *uint64
+	TotalSize     *uint64
 	Tags          []string
 }
 
@@ -24,4 +27,9 @@ type StorageShowResults struct {
 type StorageShowResult struct {
 	Result StorageInstance
 	Error  ErrorResult
+}
+
+// StorageListResult holds information about storage instances.
+type StorageListResult struct {
+	Instances []StorageInstance
 }

--- a/apiserver/storage/state.go
+++ b/apiserver/storage/state.go
@@ -7,13 +7,9 @@ import "github.com/juju/juju/state"
 
 type storageAccess interface {
 	StorageInstance(id string) (state.StorageInstance, error)
+	AllStorageInstances() ([]state.StorageInstance, error)
 }
 
 type stateShim struct {
-	state *state.State
-}
-
-// StorageInstance calls state to get information about storage instance
-func (s stateShim) StorageInstance(id string) (state.StorageInstance, error) {
-	return s.state.StorageInstance(id)
+	*state.State
 }

--- a/cmd/juju/storage/export_test.go
+++ b/cmd/juju/storage/export_test.go
@@ -5,4 +5,5 @@ package storage
 
 var (
 	GetStorageShowAPI = &getStorageShowAPI
+	GetStorageListAPI = &getStorageListAPI
 )

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -17,7 +17,7 @@ options:
 -e, --environment (= "")
    juju environment to operate in
 -o, --output (= "")
-   specify an output
+   specify an output file
 `
 
 // ListCommand attempts to release storage instance.
@@ -35,7 +35,7 @@ func (c *ListCommand) Init(args []string) (err error) {
 func (c *ListCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list",
-		Purpose: "lists storage instance",
+		Purpose: "lists storage instances",
 		Doc:     ListCommandDoc,
 	}
 }

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -1,0 +1,84 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+const ListCommandDoc = `
+List information about storage instances.
+
+options:
+-e, --environment (= "")
+   juju environment to operate in
+-o, --output (= "")
+   specify an output
+`
+
+// ListCommand attempts to release storage instance.
+type ListCommand struct {
+	StorageCommandBase
+	out cmd.Output
+}
+
+// Init implements Command.Init.
+func (c *ListCommand) Init(args []string) (err error) {
+	return cmd.CheckEmpty(args)
+}
+
+// Info implements Command.Info.
+func (c *ListCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "list",
+		Purpose: "lists storage instance",
+		Doc:     ListCommandDoc,
+	}
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *ListCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.StorageCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatListTabular,
+	})
+}
+
+// Run implements Command.Run.
+func (c *ListCommand) Run(ctx *cmd.Context) (err error) {
+	api, err := getStorageListAPI(c)
+	if err != nil {
+		return err
+	}
+	defer api.Close()
+
+	result, err := api.List()
+	if err != nil {
+		return err
+	}
+	output, err := formatStorageInfo(result)
+	if err != nil {
+		return err
+	}
+	return c.out.Write(ctx, output)
+}
+
+var (
+	getStorageListAPI = (*ListCommand).getStorageListAPI
+)
+
+// StorageAPI defines the API methods that the storage commands use.
+type StorageListAPI interface {
+	Close() error
+	List() ([]params.StorageInstance, error)
+}
+
+func (c *ListCommand) getStorageListAPI() (StorageListAPI, error) {
+	return c.NewStorageAPI()
+}

--- a/cmd/juju/storage/list_formatters.go
+++ b/cmd/juju/storage/list_formatters.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/juju/errors"
+)
+
+// formatListTabular returns a tabular summary of storage instances.
+func formatListTabular(value interface{}) ([]byte, error) {
+	storageInfo, ok := value.(map[string]StorageInfo)
+	if !ok {
+		return nil, errors.Errorf("expected value of type %T, got %T", storageInfo, value)
+	}
+	var out bytes.Buffer
+	// To format things into columns.
+	tw := tabwriter.NewWriter(&out, 0, 1, 1, ' ', 0)
+	p := func(values ...interface{}) {
+		for _, v := range values {
+			fmt.Fprintf(tw, "%v\t", v)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	storageIds := make([]string, 0, len(storageInfo))
+	for storageId := range storageInfo {
+		storageIds = append(storageIds, storageId)
+	}
+	sort.Strings(byStorageId(storageIds))
+
+	p("[Storage]")
+	p("ID\tOWNER\tLOCATION\tSIZE")
+	for _, storageId := range storageIds {
+		// TODO we should be listing attachments here,
+		// not storage instances. This needs to change
+		// when the model does. For now we are assume
+		// all owners are units (which is currently the
+		// case.)
+		info := storageInfo[storageId]
+		location := "-"
+		if info.Location != nil {
+			location = *info.Location
+		}
+		totalSize := "(unknown)"
+		if info.TotalSize != nil {
+			totalSize = fmt.Sprint(*info.TotalSize)
+		}
+		p(storageId, info.Owner, location, totalSize)
+	}
+	tw.Flush()
+
+	return out.Bytes(), nil
+}
+
+type byStorageId []string
+
+func (s byStorageId) Len() int {
+	return len(s)
+}
+
+func (s byStorageId) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
+}
+
+func (s byStorageId) Less(a, b int) bool {
+	apos := strings.LastIndex(s[a], "/")
+	bpos := strings.LastIndex(s[b], "/")
+	if apos == -1 || bpos == -1 {
+		panic("invalid storage ID")
+	}
+	aname := s[a][:apos]
+	bname := s[b][:bpos]
+	if aname == bname {
+		aid, err := strconv.Atoi(s[a][apos+1:])
+		if err != nil {
+			panic(err)
+		}
+		bid, err := strconv.Atoi(s[b][bpos+1:])
+		if err != nil {
+			panic(err)
+		}
+		return aid < bid
+	}
+	return aname < bname
+}

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -1,0 +1,112 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	"github.com/juju/cmd"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/envcmd"
+	"github.com/juju/juju/cmd/juju/storage"
+	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/testing"
+)
+
+type ListSuite struct {
+	SubStorageSuite
+	mockAPI *mockListAPI
+}
+
+var _ = gc.Suite(&ListSuite{})
+
+func (s *ListSuite) SetUpTest(c *gc.C) {
+	s.SubStorageSuite.SetUpTest(c)
+
+	s.mockAPI = &mockListAPI{}
+	s.PatchValue(storage.GetStorageListAPI, func(c *storage.ListCommand) (storage.StorageListAPI, error) {
+		return s.mockAPI, nil
+	})
+
+}
+
+func runList(c *gc.C, args []string) (*cmd.Context, error) {
+	return testing.RunCommand(c, envcmd.Wrap(&storage.ListCommand{}), args...)
+}
+
+func (s *ListSuite) TestList(c *gc.C) {
+	s.assertValidList(
+		c,
+		nil,
+		// Default format is tabular
+		`
+[Storage]   
+ID          OWNER        LOCATION  SIZE      
+db-dir/1000 postgresql/0 /srv/data 1024      
+shared-fs/0 transcode/0  /srv      (unknown) 
+
+`[1:],
+	)
+}
+
+func (s *ListSuite) TestListYAML(c *gc.C) {
+	s.assertValidList(
+		c,
+		[]string{"--format", "yaml"},
+		`
+db-dir/1000:
+  storage: db-dir
+  owner: postgresql/0
+  location: /srv/data
+  available-size: 1
+  total-size: 1024
+  tags:
+  - tests
+  - well
+  - maybe
+shared-fs/0:
+  storage: shared-fs
+  owner: transcode/0
+  location: /srv
+`[1:],
+	)
+}
+
+func (s *ListSuite) assertValidList(c *gc.C, args []string, expected string) {
+	context, err := runList(c, args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained := testing.Stdout(context)
+	c.Assert(obtained, gc.Equals, expected)
+}
+
+type mockListAPI struct {
+}
+
+func (s mockListAPI) Close() error {
+	return nil
+}
+
+func (s mockListAPI) List() ([]params.StorageInstance, error) {
+	tcLocation := "/srv"
+	pgLocation := "/srv/data"
+	pgAvailableSize := uint64(1)
+	pgTotalSize := uint64(1024)
+
+	results := []params.StorageInstance{{
+		StorageTag: "storage-shared-fs-0",
+		OwnerTag:   "unit-transcode-0",
+		Location:   &tcLocation,
+	}, {
+		StorageTag:    "storage-db-dir-1000",
+		OwnerTag:      "unit-postgresql-0",
+		Location:      &pgLocation,
+		AvailableSize: &pgAvailableSize,
+		TotalSize:     &pgTotalSize,
+		Tags:          []string{"tests", "well", "maybe"},
+	}}
+
+	return results, nil
+}

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -22,7 +22,7 @@ options:
 -e, --environment (= "")
    juju environment to operate in
 -o, --output (= "")
-   specify an output
+   specify an output file
 [space separated storage ids]
 `
 

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -57,17 +57,6 @@ func (c *ShowCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "yaml", cmd.DefaultFormatters)
 }
 
-// StorageInfo defines the serialization behaviour of the storage information.
-type StorageInfo struct {
-	StorageTag    string   `yaml:"storage-tag" json:"storage-tag"`
-	StorageName   string   `yaml:"storage-name" json:"storage-name"`
-	OwnerTag      string   `yaml:"owner-tag" json:"owner-tag"`
-	Location      string   `yaml:"location,omitempty" json:"location,omitempty"`
-	AvailableSize uint64   `yaml:"available-size" json:"available-size"`
-	TotalSize     uint64   `yaml:"total-size" json:"total-size"`
-	Tags          []string `yaml:"tags,omitempty" json:"tags,omitempty"`
-}
-
 // Run implements Command.Run.
 func (c *ShowCommand) Run(ctx *cmd.Context) (err error) {
 	api, err := getStorageShowAPI(c)
@@ -80,7 +69,10 @@ func (c *ShowCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	output := c.apiStoragesToInstanceSlice(result)
+	output, err := formatStorageInfo(result)
+	if err != nil {
+		return err
+	}
 	return c.out.Write(ctx, output)
 }
 
@@ -104,21 +96,4 @@ type StorageShowAPI interface {
 
 func (c *ShowCommand) getStorageShowAPI() (StorageShowAPI, error) {
 	return c.NewStorageAPI()
-}
-
-func (c *ShowCommand) apiStoragesToInstanceSlice(all []params.StorageInstance) []StorageInfo {
-	var output []StorageInfo
-	for _, one := range all {
-		outInfo := StorageInfo{
-			StorageTag:    one.StorageTag,
-			StorageName:   one.StorageName,
-			Location:      one.Location,
-			OwnerTag:      one.OwnerTag,
-			AvailableSize: one.AvailableSize,
-			TotalSize:     one.TotalSize,
-			Tags:          one.Tags,
-		}
-		output = append(output, outInfo)
-	}
-	return output
 }

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -18,7 +18,7 @@ import (
 
 type ShowSuite struct {
 	SubStorageSuite
-	mockAPI *mockStorageAPI
+	mockAPI *mockShowAPI
 }
 
 var _ = gc.Suite(&ShowSuite{})
@@ -26,7 +26,7 @@ var _ = gc.Suite(&ShowSuite{})
 func (s *ShowSuite) SetUpTest(c *gc.C) {
 	s.SubStorageSuite.SetUpTest(c)
 
-	s.mockAPI = &mockStorageAPI{}
+	s.mockAPI = &mockShowAPI{}
 	s.PatchValue(storage.GetStorageShowAPI, func(c *storage.ShowCommand) (storage.StorageShowAPI, error) {
 		return s.mockAPI, nil
 	})
@@ -42,9 +42,10 @@ func (s *ShowSuite) TestShow(c *gc.C) {
 		c,
 		[]string{"shared-fs/0"},
 		// Default format is yaml
-		`- storage-tag: storage-shared-fs-0
-  storage-name: storage-name
-  owner-tag: unitTag
+		`
+shared-fs/0:
+  storage: shared-fs
+  owner: postgresql/0
   location: witty
   available-size: 30
   total-size: 100
@@ -52,7 +53,7 @@ func (s *ShowSuite) TestShow(c *gc.C) {
   - tests
   - well
   - maybe
-`,
+`[1:],
 	)
 }
 
@@ -60,7 +61,7 @@ func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	s.assertValidShow(
 		c,
 		[]string{"shared-fs/0", "--format", "json"},
-		`[{"storage-tag":"storage-shared-fs-0","storage-name":"storage-name","owner-tag":"unitTag","location":"witty","available-size":30,"total-size":100,"tags":["tests","well","maybe"]}]
+		`{"shared-fs/0":{"storage":"shared-fs","owner":"postgresql/0","location":"witty","available-size":30,"total-size":100,"tags":["tests","well","maybe"]}}
 `,
 	)
 }
@@ -69,9 +70,10 @@ func (s *ShowSuite) TestShowMultipleReturn(c *gc.C) {
 	s.assertValidShow(
 		c,
 		[]string{"shared-fs/0", "db-dir/1000"},
-		`- storage-tag: storage-shared-fs-0
-  storage-name: storage-name
-  owner-tag: unitTag
+		`
+db-dir/1000:
+  storage: db-dir
+  owner: postgresql/0
   location: witty
   available-size: 30
   total-size: 100
@@ -79,9 +81,9 @@ func (s *ShowSuite) TestShowMultipleReturn(c *gc.C) {
   - tests
   - well
   - maybe
-- storage-tag: storage-db-dir-1000
-  storage-name: storage-name
-  owner-tag: unitTag
+shared-fs/0:
+  storage: shared-fs
+  owner: postgresql/0
   location: witty
   available-size: 30
   total-size: 100
@@ -89,7 +91,7 @@ func (s *ShowSuite) TestShowMultipleReturn(c *gc.C) {
   - tests
   - well
   - maybe
-`,
+`[1:],
 	)
 }
 
@@ -101,24 +103,27 @@ func (s *ShowSuite) assertValidShow(c *gc.C, args []string, expected string) {
 	c.Assert(obtained, gc.Equals, expected)
 }
 
-type mockStorageAPI struct {
+type mockShowAPI struct {
 }
 
-func (s mockStorageAPI) Close() error {
+func (s mockShowAPI) Close() error {
 	return nil
 }
 
-func (s mockStorageAPI) Show(tags []names.StorageTag) ([]params.StorageInstance, error) {
+func (s mockShowAPI) Show(tags []names.StorageTag) ([]params.StorageInstance, error) {
 	results := make([]params.StorageInstance, len(tags))
+
+	location := "witty"
+	availableSize := uint64(30)
+	totalSize := uint64(100)
 
 	for i, tag := range tags {
 		results[i] = params.StorageInstance{
 			StorageTag:    tag.String(),
-			StorageName:   "storage-name",
-			OwnerTag:      "unitTag",
-			Location:      "witty",
-			AvailableSize: 30,
-			TotalSize:     100,
+			OwnerTag:      "unit-postgresql-0",
+			Location:      &location,
+			AvailableSize: &availableSize,
+			TotalSize:     &totalSize,
 			Tags:          []string{"tests", "well", "maybe"},
 		}
 	}

--- a/cmd/juju/storage/storage_test.go
+++ b/cmd/juju/storage/storage_test.go
@@ -14,6 +14,7 @@ import (
 
 var expectedSubCommmandNames = []string{
 	"help",
+	"list",
 	"show",
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -203,6 +203,22 @@ func (st *State) StorageInstance(id string) (StorageInstance, error) {
 	return &s, nil
 }
 
+func (st *State) AllStorageInstances() ([]StorageInstance, error) {
+	coll, closer := st.getCollection(storageInstancesC)
+	defer closer()
+
+	var storageInstances []StorageInstance
+	var doc storageInstanceDoc
+	iter := coll.Find(nil).Iter()
+	for iter.Next(&doc) {
+		storageInstances = append(storageInstances, &storageInstance{st, doc})
+	}
+	if err := iter.Close(); err != nil {
+		return nil, errors.Annotate(err, "cannot get storage instances")
+	}
+	return storageInstances, nil
+}
+
 func (st *State) SetStorageInstanceInfo(storageId string, info StorageInstanceInfo) error {
 	ops := []txn.Op{{
 		C:  storageInstancesC,


### PR DESCRIPTION
This commit introduces "juju storage list" to list
all of the storage instances in the environment.
The default output is a tabular format, similar to
"juju status --format tabular".

The existing "juju storage show" has been tweaked
to output as a map, rather than a slice. This makes
the output more like "juju status". We also translate
tags to IDs (unit/service name, storage ID), as tags
are not intended for users' eyes.

The StorageName value is now computed from the storage
ID. Finally, the "location", "available-size" and
"total-size" fields are omitted if unavailable. To
effect this, we make their types pointers, so they
are nullable.

This commit requires https://github.com/juju/names/pull/38