### PR TITLE
Rootfs provider/pool, various improvements

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -343,3 +343,21 @@ func (m *Machine) SetProvisionedBlockDevices(devices []storage.BlockDevice) erro
 	}
 	return results.OneError()
 }
+
+// DEMO ONLY - NOT PRODUCTION
+func (m *Machine) StorageParams() ([]storage.VolumeParams, error) {
+	var results params.StorageParamsResults
+	args := params.Entities{Entities: []params.Entity{{m.tag.String()}}}
+	err := m.st.facade.FacadeCall("MachineStorageParams", args, &results)
+	if err != nil {
+		return nil, err
+	}
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return result.Volumes, nil
+}

--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -345,19 +345,35 @@ func (m *Machine) SetProvisionedBlockDevices(devices []storage.BlockDevice) erro
 }
 
 // DEMO ONLY - NOT PRODUCTION
-func (m *Machine) StorageParams() ([]storage.VolumeParams, error) {
+func (m *Machine) SetProvisionedFilesystems(filesystems []storage.Filesystem) error {
+	args := params.SetMachineFilesystems{
+		MachineFilesystems: []params.MachineFilesystems{{
+			Machine:     m.Tag().String(),
+			Filesystems: filesystems,
+		}},
+	}
+	var results params.ErrorResults
+	err := m.st.facade.FacadeCall("SetProvisionedFilesystems", args, &results)
+	if err != nil {
+		return err
+	}
+	return results.OneError()
+}
+
+// DEMO ONLY - NOT PRODUCTION
+func (m *Machine) StorageParams() ([]storage.VolumeParams, []storage.FilesystemParams, error) {
 	var results params.StorageParamsResults
 	args := params.Entities{Entities: []params.Entity{{m.tag.String()}}}
 	err := m.st.facade.FacadeCall("MachineStorageParams", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(results.Results) != 1 {
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return nil, nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return nil, result.Error
+		return nil, nil, result.Error
 	}
-	return result.Volumes, nil
+	return result.Volumes, result.Filesystems, nil
 }

--- a/apiserver/diskformatter/diskformatter.go
+++ b/apiserver/diskformatter/diskformatter.go
@@ -160,7 +160,10 @@ func (a *DiskFormatterAPI) SetMountPoints(args params.StorageMountPoints) (param
 		if err != nil || !canAccess(storageInstance.Owner()) {
 			return common.ErrPerm
 		}
-		info := state.StorageInstanceInfo{arg.MountPoint}
+		info := state.StorageInstanceInfo{
+			Location: arg.MountPoint,
+			// TODO(axw) size
+		}
 		return a.st.SetStorageInstanceInfo(storageTag.Id(), info)
 	}
 	for i, arg := range args.StorageMountPoints {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -848,6 +848,19 @@ type StorageInstanceResults struct {
 	Results []StorageInstanceResult `json:"results,omitempty"`
 }
 
+// StorageParamsResult holds the result of an API call to retrieve parameters
+// for a machine's unprovisioned storage instances.
+type StorageParamsResult struct {
+	Volumes []storage.VolumeParams `json:"volumes"`
+	Error   *Error                 `json:"error,omitempty"`
+}
+
+// StorageParamsResults holds the result of an API call to retrieve parameters
+// for multiple machines' unprovisioned storage instances.
+type StorageParamsResults struct {
+	Results []StorageParamsResult `json:"results,omitempty"`
+}
+
 // UnitStorageInstances holds the storage instances for a given unit.
 type UnitStorageInstances struct {
 	Instances []storage.StorageInstance `json:"instances,omitempty"`

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -795,6 +795,19 @@ type SetMachineBlockDevices struct {
 	MachineBlockDevices []MachineBlockDevices
 }
 
+// MachineFilesystems holds a machine tag and the filesystems present
+// on that machine.
+type MachineFilesystems struct {
+	Machine     string
+	Filesystems []storage.Filesystem
+}
+
+// SetMachineFilesystems holds the arguments for recording the filesystems
+// present on a set of machines.
+type SetMachineFilesystems struct {
+	MachineFilesystems []MachineFilesystems
+}
+
 // BlockDeviceResult holds the result of an API call to retrieve details
 // of a block device.
 type BlockDeviceResult struct {
@@ -851,8 +864,9 @@ type StorageInstanceResults struct {
 // StorageParamsResult holds the result of an API call to retrieve parameters
 // for a machine's unprovisioned storage instances.
 type StorageParamsResult struct {
-	Volumes []storage.VolumeParams `json:"volumes"`
-	Error   *Error                 `json:"error,omitempty"`
+	Volumes     []storage.VolumeParams     `json:"volumes"`
+	Filesystems []storage.FilesystemParams `json:"filesystems"`
+	Error       *Error                     `json:"error,omitempty"`
 }
 
 // StorageParamsResults holds the result of an API call to retrieve parameters

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/set"
 
@@ -21,6 +22,8 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/pool"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.provisioner")
 
 func init() {
 	common.RegisterStandardFacade("Provisioner", 0, NewProvisionerAPI)
@@ -537,7 +540,7 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]storage.Volume
 		}
 		var options map[string]interface{}
 		var providerType storage.ProviderType
-		providerType, options, err = deviceOptions(p.st, params.Pool)
+		providerType, options, err = poolConfig(p.st, params.Pool)
 		if err != nil {
 			return nil, errors.Errorf("cannot get options for pool %q", params.Pool)
 		}
@@ -552,7 +555,55 @@ func (p *ProvisionerAPI) machineVolumeParams(m *state.Machine) ([]storage.Volume
 	return allParams, nil
 }
 
-func deviceOptions(st *state.State, poolName string) (storage.ProviderType, map[string]interface{}, error) {
+// machineFilesystemParams retrieves FilesystemParams for the filesystems that
+// should be provisioned with and attached to the machine. The client should
+// ignore parameters that it does not know how to handle.
+func (p *ProvisionerAPI) machineFilesystemParams(m *state.Machine) ([]storage.FilesystemParams, error) {
+	var allStorageInstances []state.StorageInstance
+	units, err := m.Units()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := m.InstanceId(); err != nil {
+		// even return on IsNotProvisioned, this should not be
+		// called for unprovisioned machines.
+		return nil, err
+	}
+	for _, u := range units {
+		storageInstances, err := u.StorageInstances()
+		if err != nil {
+			return nil, err
+		}
+		for _, si := range storageInstances {
+			if si.Kind() == state.StorageKindFilesystem {
+				allStorageInstances = append(allStorageInstances, si)
+			}
+		}
+	}
+	allParams := make([]storage.FilesystemParams, 0, len(allStorageInstances))
+	for _, si := range allStorageInstances {
+		params, ok := si.Params()
+		if !ok {
+			continue
+		}
+		var options map[string]interface{}
+		var providerType storage.ProviderType
+		providerType, options, err = poolConfig(p.st, params.Pool)
+		if err != nil {
+			return nil, errors.Errorf("cannot get options for pool %q", params.Pool)
+		}
+		allParams = append(allParams, storage.FilesystemParams{
+			si.Id(), // HACK
+			params.Size,
+			params.Location,
+			options,
+			providerType,
+		})
+	}
+	return allParams, nil
+}
+
+func poolConfig(st *state.State, poolName string) (storage.ProviderType, map[string]interface{}, error) {
 	pm := pool.NewPoolManager(state.NewStateSettings(st))
 	p, err := pm.Get(poolName)
 	if err != nil {
@@ -774,6 +825,38 @@ func (p *ProvisionerAPI) SetProvisionedBlockDevices(args params.SetMachineBlockD
 }
 
 // DEMO ONLY - NOT PRODUCTION
+func (p *ProvisionerAPI) SetProvisionedFilesystems(args params.SetMachineFilesystems) (params.ErrorResults, error) {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.MachineFilesystems)),
+	}
+	canAccess, err := p.getAuthFunc()
+	if err != nil {
+		return result, err
+	}
+	one := func(tag string, filesystems []storage.Filesystem) error {
+		machineTag, err := names.ParseMachineTag(tag)
+		if err != nil || !canAccess(machineTag) {
+			return common.ErrPerm
+		}
+		for _, fs := range filesystems {
+			info := state.StorageInstanceInfo{
+				Location: fs.Location,
+				Size:     fs.Size,
+			}
+			if err := p.st.SetStorageInstanceInfo(fs.Name, info); err != nil {
+				return errors.Annotatef(err, "setting storage info for %q", fs.Name)
+			}
+		}
+		return nil
+	}
+	for i, arg := range args.MachineFilesystems {
+		err := one(arg.Machine, arg.Filesystems)
+		result.Results[i].Error = common.ServerError(err)
+	}
+	return result, nil
+}
+
+// DEMO ONLY - NOT PRODUCTION
 func (p *ProvisionerAPI) MachineStorageParams(args params.Entities) (params.StorageParamsResults, error) {
 	results := params.StorageParamsResults{
 		Results: make([]params.StorageParamsResult, len(args.Entities)),
@@ -782,21 +865,30 @@ func (p *ProvisionerAPI) MachineStorageParams(args params.Entities) (params.Stor
 	if err != nil {
 		return params.StorageParamsResults{}, err
 	}
-	one := func(entity params.Entity) ([]storage.VolumeParams, error) {
+	one := func(entity params.Entity) ([]storage.VolumeParams, []storage.FilesystemParams, error) {
 		tag, err := names.ParseMachineTag(entity.Tag)
 		if err != nil {
-			return nil, common.ErrPerm
+			return nil, nil, common.ErrPerm
 		}
 		machine, err := p.getMachine(canAccess, tag)
 		if err != nil {
-			return nil, common.ErrPerm
+			return nil, nil, common.ErrPerm
 		}
-		return p.machineVolumeParams(machine)
+		volumes, err := p.machineVolumeParams(machine)
+		if err != nil {
+			return nil, nil, err
+		}
+		filesystems, err := p.machineFilesystemParams(machine)
+		if err != nil {
+			return nil, nil, err
+		}
+		return volumes, filesystems, nil
 	}
 	for i, entity := range args.Entities {
-		volumes, err := one(entity)
+		volumes, filesystems, err := one(entity)
 		if err == nil {
 			results.Results[i].Volumes = volumes
+			results.Results[i].Filesystems = filesystems
 		}
 		results.Results[i].Error = common.ServerError(err)
 	}

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -105,7 +105,8 @@ func (api *API) getStorageInstance(si state.StorageInstance) (params.StorageInst
 	info, err := si.Info()
 	if err == nil {
 		location = &info.Location
-		// TODO(axw) total/avail size.
+		totalSize = &info.Size
+		// TODO(axw) avail size?
 	} else if !errors.IsNotProvisioned(err) {
 		return params.StorageInstance{}, err
 	}

--- a/cmd/juju/storage/list_formatters.go
+++ b/cmd/juju/storage/list_formatters.go
@@ -34,7 +34,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 	sort.Strings(byStorageId(storageIds))
 
 	p("[Storage]")
-	p("ID\tOWNER\tLOCATION\tSIZE")
+	p("ID\tOWNER\tSIZE\tLOCATION")
 	for _, storageId := range storageIds {
 		// TODO we should be listing attachments here,
 		// not storage instances. This needs to change
@@ -50,7 +50,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 		if info.TotalSize != nil {
 			totalSize = fmt.Sprint(*info.TotalSize)
 		}
-		p(storageId, info.Owner, location, totalSize)
+		p(storageId, info.Owner, totalSize, location)
 	}
 	tw.Flush()
 

--- a/cmd/juju/storage/list_formatters.go
+++ b/cmd/juju/storage/list_formatters.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
 )
 
@@ -48,7 +49,7 @@ func formatListTabular(value interface{}) ([]byte, error) {
 		}
 		totalSize := "(unknown)"
 		if info.TotalSize != nil {
-			totalSize = fmt.Sprint(*info.TotalSize)
+			totalSize = humanize.IBytes(*info.TotalSize * humanize.MiByte)
 		}
 		p(storageId, info.Owner, totalSize, location)
 	}

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,9 +43,9 @@ func (s *ListSuite) TestList(c *gc.C) {
 		// Default format is tabular
 		`
 [Storage]   
-ID          OWNER        LOCATION  SIZE      
-db-dir/1000 postgresql/0 /srv/data 1024      
-shared-fs/0 transcode/0  /srv      (unknown) 
+ID          OWNER        SIZE      LOCATION  
+db-dir/1000 postgresql/0 1.0GiB    /srv/data 
+shared-fs/0 transcode/0  (unknown) /srv      
 
 `[1:],
 	)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,6 +4,7 @@ code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
 code.google.com/p/go.net	hg	c17ad62118ea511e1051721b429779fa40bddc74	116
 code.google.com/p/winsvc	hg	d6f79143ccd1138cc9d86c9fc75b1d6f8b1b95fb	10
 github.com/bmizerany/pat	git	48be7df2c27e1cec821a3284a683ce6ef90d9052	2014-04-29T04:34:05Z
+github.com/dustin/go-humanize	git	145fabdb1ab757076a70a886d092a3af27f66f4c	2014-12-28T07:11:48Z
 github.com/joyent/gocommon	git	40c7818502f7c1ebbb13dab185a26e77b746ff40	2014-05-24T00:08:47Z
 github.com/joyent/gomanta	git	cabd97b029d931836571f00b7e48c331809a30b7	2014-05-24T00:09:46Z
 github.com/joyent/gosdc	git	2f11feadd2d9891e92296a1077c3e2e56939547d	2014-05-24T00:08:15Z

--- a/provider/ec2/disks.go
+++ b/provider/ec2/disks.go
@@ -77,9 +77,12 @@ func getBlockDeviceMappings(
 	// many there are and how big each one is. We also need to
 	// unmap ephemeral0 in cloud-init.
 
-	volumes := make([]storage.BlockDevice, len(args.Volumes))
+	volumes := make([]storage.BlockDevice, 0, len(args.Volumes))
 	nextDeviceName := blockDeviceNamer(virtType == paravirtual)
-	for i, params := range args.Volumes {
+	for _, params := range args.Volumes {
+		if params.Provider != providerstorage.EBSProviderType {
+			continue
+		}
 		// Check minimum constraints can be satisfied.
 		if err := validateVolumeParams(params); err != nil {
 			return nil, nil, errors.Annotate(err, "invalid volume parameters")
@@ -113,7 +116,7 @@ func getBlockDeviceMappings(
 			// been created, which will create the volumes too.
 		}
 		blockDeviceMappings = append(blockDeviceMappings, mapping)
-		volumes[i] = volume
+		volumes = append(volumes, volume)
 	}
 	return blockDeviceMappings, volumes, nil
 }

--- a/provider/ec2/disks_test.go
+++ b/provider/ec2/disks_test.go
@@ -82,10 +82,15 @@ func (*DisksSuite) TestBlockDeviceNamer(c *gc.C) {
 func (*DisksSuite) TestGetBlockDeviceMappings(c *gc.C) {
 	mapping, blockDeviceInfo, err := ec2.GetBlockDeviceMappings(
 		"pv", &environs.StartInstanceParams{Volumes: []storage.VolumeParams{{
-			Name: "0", Size: 1234,
+			Provider: "ebs",
+			Name:     "0", Size: 1234,
 		}, {
-			Name: "1", Size: 4321,
+			Provider: "ebs",
+			Name:     "1", Size: 4321,
 			Options: map[string]interface{}{"volume-type": "standard", "iops": 1234},
+		}, {
+			// this should be ignored
+			Provider: "summink",
 		}}},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -893,11 +893,14 @@ func (t *localServerSuite) TestStartInstanceVolumes(c *gc.C) {
 
 	params := environs.StartInstanceParams{
 		Volumes: []storage.VolumeParams{{
-			Size: 512, // round up to 1GiB
+			Size:     512, // round up to 1GiB
+			Provider: "ebs",
 		}, {
-			Size: 1024, // 1GiB exactly
+			Size:     1024, // 1GiB exactly
+			Provider: "ebs",
 		}, {
-			Size: 1025, // round up to 2GiB
+			Size:     1025, // round up to 2GiB
+			Provider: "ebs",
 		}},
 	}
 	result, err := testing.StartInstanceWithParams(env, "1", params, nil)

--- a/provider/ec2/storage/ebs.go
+++ b/provider/ec2/storage/ebs.go
@@ -91,6 +91,10 @@ func (e *ebsProvider) VolumeSource(environConfig *config.Config, providerConfig 
 	panic("not implemented")
 }
 
+func (e *ebsProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
+}
+
 type ebsVolueSoucre struct {
 }
 

--- a/provider/ec2/storage/init.go
+++ b/provider/ec2/storage/init.go
@@ -14,6 +14,7 @@ func init() {
 	storage.RegisterProvider(EBSProviderType, &ebsProvider{})
 	storage.RegisterEnvironStorageProviders("ec2", EBSProviderType)
 	storage.RegisterEnvironStorageProviders("ec2", provider.LoopProviderType)
+	storage.RegisterEnvironStorageProviders("ec2", provider.RootfsProviderType)
 
 	storage.RegisterDefaultPool("ec2", storage.StorageKindBlock, EBSPool)
 }

--- a/provider/local/environprovider.go
+++ b/provider/local/environprovider.go
@@ -40,8 +40,21 @@ var providerInstance = &environProvider{}
 func init() {
 	environs.RegisterProvider(provider.Local, providerInstance)
 
-	storage.RegisterEnvironStorageProviders(provider.Local, storageprovider.LoopProviderType)
-	storage.RegisterDefaultPool(provider.Local, storage.StorageKindBlock, storageprovider.LoopPool)
+	storage.RegisterEnvironStorageProviders(
+		provider.Local,
+		storageprovider.LoopProviderType,
+		storageprovider.RootfsProviderType,
+	)
+	storage.RegisterDefaultPool(
+		provider.Local,
+		storage.StorageKindBlock,
+		storageprovider.LoopPool,
+	)
+	storage.RegisterDefaultPool(
+		provider.Local,
+		storage.StorageKindFilesystem,
+		storageprovider.RootfsPool,
+	)
 }
 
 var userCurrent = user.Current

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -327,6 +327,7 @@ func setProvisionedBlockDeviceInfo(st *State, machineId string, blockDevices map
 				storageInstanceInfo := &StorageInstanceInfo{
 					// Especially not this.
 					Location: "/dev/" + info.DeviceName,
+					Size:     info.Size,
 				}
 				ops = append(ops, txn.Op{
 					C:  storageInstancesC,

--- a/state/storage.go
+++ b/state/storage.go
@@ -167,6 +167,9 @@ type StorageInstanceInfo struct {
 	// Location is the location of the storage
 	// instance, e.g. the mount point.
 	Location string `bson:"location"`
+
+	// Size is the actual size of the storage instance, in MiB.
+	Size uint64 `bson:"size"`
 }
 
 // StorageInstanceParams records parameters for provisioning a new
@@ -175,6 +178,7 @@ type StorageInstanceParams struct {
 	Size     uint64 `bson:"size"`
 	Location string `bson:"location,omitempty"`
 	ReadOnly bool   `bson:"read-only"`
+	Pool     string `bson:"pool"`
 }
 
 // newStorageInstanceId returns a unique storage instance name. The name
@@ -274,6 +278,7 @@ func createStorageInstanceOps(
 			Size:     t.cons.Size,
 			Location: t.meta.Location,
 			ReadOnly: t.meta.ReadOnly,
+			Pool:     t.cons.Pool,
 		}
 
 		owner := ownerTag.String()

--- a/state/unit.go
+++ b/state/unit.go
@@ -1352,13 +1352,18 @@ func (u *Unit) AssignToNewMachine() (err error) {
 	}
 	var blockDeviceParams []BlockDeviceParams
 	for _, storageInstance := range storageInstances {
+		pool := storageCons[storageInstance.StorageName()].Pool
+		// HACK HACK HACK
+		if pool == "rootfs" || pool == "tmpfs" {
+			continue
+		}
 		// TODO(axw) consult storage provider to see if we need to request
 		// a block device for the storage instance.
 		storageInstanceParams, _ := storageInstance.Params()
 		blockDeviceParams = append(blockDeviceParams, BlockDeviceParams{
 			storageInstance: storageInstance.Id(),
 			Size:            storageInstanceParams.Size,
-			Pool:            storageCons[storageInstance.StorageName()].Pool,
+			Pool:            pool,
 		})
 	}
 	template := MachineTemplate{

--- a/storage/provider/init.go
+++ b/storage/provider/init.go
@@ -15,10 +15,8 @@ import (
 var logger = loggo.GetLogger("juju.storage.provider")
 
 func init() {
-
 	storage.RegisterProvider(LoopProviderType, &loopProvider{RunCmdFn()})
-
-	storage.RegisterDefaultPool("local", storage.StorageKindBlock, LoopPool)
+	storage.RegisterProvider(RootfsProviderType, &rootfsProvider{RunCmdFn()})
 }
 
 // RunCmdFn returns a function which will run a command and return the

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -67,6 +67,10 @@ func (lp *loopProvider) VolumeSource(environConfig *config.Config, providerConfi
 	}, nil
 }
 
+func (lp *loopProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.NotSupportedf("filesystems")
+}
+
 // blockDevicePlus contains a reference to the BlockDevice that most
 // of storage works with in addition to other information that is
 // useful to the internal implementation of loopVolumeSource.

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/storage"
+)
+
+const (
+	RootfsProviderType = storage.ProviderType("rootfs")
+	RootfsPool         = "rootfs"
+
+	// Config attributes
+	RootfsStorageDir = "storage-dir"
+)
+
+// rootfsProviders create volume sources which use loop devices.
+type rootfsProvider struct {
+	run RunCommandFn
+}
+
+var (
+	_ storage.Provider = (*rootfsProvider)(nil)
+)
+
+// ValidateConfig is defined on the Provider interface.
+func (p *rootfsProvider) ValidateConfig(providerConfig *storage.Config) error {
+	dir, ok := providerConfig.ValueString(RootfsStorageDir)
+	if !ok || dir == "" {
+		return errors.New("no storage directory specified")
+	}
+	return nil
+}
+
+func (p *rootfsProvider) VolumeSource(environConfig *config.Config, providerConfig *storage.Config) (storage.VolumeSource, error) {
+	return nil, errors.NotSupportedf("volumes")
+}
+
+func (p *rootfsProvider) FilesystemSource(environConfig *config.Config, providerConfig *storage.Config) (storage.FilesystemSource, error) {
+	if err := p.ValidateConfig(providerConfig); err != nil {
+		return nil, err
+	}
+	storageDir, _ := providerConfig.ValueString(RootfsStorageDir)
+	return &rootfsSource{p.run, storageDir}, nil
+}
+
+type rootfsSource struct {
+	run        RunCommandFn
+	storageDir string
+}
+
+var _ storage.FilesystemSource = (*rootfsSource)(nil)
+
+func (s *rootfsSource) CreateFilesystems(args []storage.FilesystemParams) ([]storage.Filesystem, error) {
+	filesystems := make([]storage.Filesystem, 0, len(args))
+	for _, arg := range args {
+		location := arg.Location
+		if location == "" {
+			location = filepath.Join(s.storageDir, arg.Name)
+		}
+		if _, err := os.Lstat(location); !os.IsNotExist(err) {
+			// Ignore this request if the location already exists.
+			continue
+		}
+		if err := os.MkdirAll(location, 0755); err != nil {
+			return nil, errors.Annotate(err, "could not create directory")
+		}
+		dfOutput, err := s.run("df", "--output=size", location)
+		if err != nil {
+			os.Remove(location)
+			return nil, errors.Annotate(err, "getting size")
+		}
+		lines := strings.SplitN(dfOutput, "\n", 2)
+		blocks, err := strconv.ParseUint(strings.TrimSpace(lines[1]), 10, 64)
+		if err != nil {
+			os.Remove(location)
+			return nil, errors.Annotate(err, "getting size")
+		}
+		sizeInMiB := blocks / 1024
+		if sizeInMiB < arg.Size {
+			os.Remove(location)
+			return nil, errors.Annotatef(err, "filesystem is not big enough (%dM < %dM)", sizeInMiB, arg.Size)
+		}
+
+		fs := storage.Filesystem{
+			Name:     arg.Name,
+			Size:     sizeInMiB,
+			Location: location,
+		}
+		filesystems = append(filesystems, fs)
+	}
+	return filesystems, nil
+}

--- a/upgrades/storage.go
+++ b/upgrades/storage.go
@@ -39,7 +39,16 @@ func AddDefaultStoragePools(st *state.State, agentConfig agent.Config) error {
 		}
 	}
 
+	// Register the "rootfs" pool.
+	if err := addDefaultPool(pm, provider.RootfsPool, provider.RootfsProviderType, map[string]interface{}{}); err != nil {
+		return err
+	}
+
 	// Register the default loop pool.
+	//
+	// TODO(axw) this is broken. The data-dir cannot be encoded in the config, because the loop
+	// provider operates on different machines. It's not necessarily true that each machine
+	// has the same data-dir path.
 	cfg := map[string]interface{}{
 		provider.LoopDataDir: filepath.Join(agentConfig.DataDir(), "storage", "block", "loop"),
 	}

--- a/worker/storage/provisioner.go
+++ b/worker/storage/provisioner.go
@@ -93,7 +93,7 @@ func (p *storageProvisioner) loop() error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			logger.Infof("volumes: %+v", volumes)
+			logger.Debugf("volumes: %+v", volumes)
 			if err := p.provisionVolumes(environConfig, volumes); err != nil {
 				return errors.Trace(err)
 			}
@@ -134,7 +134,7 @@ func (p *storageProvisioner) provisionVolumes(environConfig *config.Config, volu
 		}
 		logger.Infof("block devices created: %v", blockDevices)
 		if err := p.machine.SetProvisionedBlockDevices(blockDevices); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 	}
 	return nil


### PR DESCRIPTION
- New rootfs provider that creates "filesystems" (just directories) within the root filesystem.
- Fixes to loop provider, and storage provisioner.
- Modified storage provisioner to poll for storage params rather than using ProvisioningInfo.
- Tweaks to "juju storage list":
    * swap SIZE and LOCATION.
    * fill in the SIZE values in state (except in formatted block devices)
    * output SIZE in a human-readable format