### PR TITLE
Test fixes and default storage size

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -477,6 +477,10 @@ func validateStorageConstraints(st *State, cons map[string]StorageConstraints, c
 				charmMeta.Name, name, charmStorage.CountMax, cons.Count,
 			)
 		}
+		// TODO - use charm min size when available
+		if cons.Size == 0 {
+			cons.Size = 1024
+		}
 	}
 	// Ensure all stores have constraints specified. Defaults should have
 	// been set by this point, if the user didn't specify constraints.

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -84,7 +84,7 @@ func ParseConstraints(s string) (Constraints, error) {
 		}
 		logger.Warningf("ignoring unknown storage constraint %q", field)
 	}
-	if cons.Count == 0 && cons.Size > 0 {
+	if cons.Count == 0 {
 		cons.Count = 1
 	}
 	return cons, nil

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -84,6 +84,9 @@ func ParseConstraints(s string) (Constraints, error) {
 		}
 		logger.Warningf("ignoring unknown storage constraint %q", field)
 	}
+	if cons.Count == 0 && cons.Size == 0 && cons.Pool == "" {
+		return Constraints{}, errors.New("storage constraints require at least one field to be specified")
+	}
 	if cons.Count == 0 {
 		cons.Count = 1
 	}

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -24,10 +24,15 @@ func (s *ConstraintsSuite) TestParseConstraintsStoragePool(c *gc.C) {
 		Size:  1,
 	})
 	s.testParse(c, "pool,", storage.Constraints{
-		Pool: "pool",
+		Pool:  "pool",
+		Count: 1,
 	})
-	s.testParse(c, "", storage.Constraints{})
-	s.testParse(c, ",", storage.Constraints{})
+	s.testParse(c, "", storage.Constraints{
+		Count: 1,
+	})
+	s.testParse(c, ",", storage.Constraints{
+		Count: 1,
+	})
 	s.testParse(c, "1M", storage.Constraints{
 		Size:  1,
 		Count: 1,
@@ -59,7 +64,8 @@ func (s *ConstraintsSuite) TestParseConstraintsOptions(c *gc.C) {
 		Size:  1,
 	})
 	s.testParse(c, "p,anyoldjunk", storage.Constraints{
-		Pool: "p",
+		Pool:  "p",
+		Count: 1,
 	})
 }
 

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -27,12 +27,6 @@ func (s *ConstraintsSuite) TestParseConstraintsStoragePool(c *gc.C) {
 		Pool:  "pool",
 		Count: 1,
 	})
-	s.testParse(c, "", storage.Constraints{
-		Count: 1,
-	})
-	s.testParse(c, ",", storage.Constraints{
-		Count: 1,
-	})
 	s.testParse(c, "1M", storage.Constraints{
 		Size:  1,
 		Count: 1,
@@ -73,6 +67,8 @@ func (s *ConstraintsSuite) TestParseConstraintsCountRange(c *gc.C) {
 	s.testParseError(c, "p,0,100M", `cannot parse count: count must be greater than zero, got "0"`)
 	s.testParseError(c, "p,00,100M", `cannot parse count: count must be greater than zero, got "00"`)
 	s.testParseError(c, "p,-1,100M", `cannot parse count: count must be greater than zero, got "-1"`)
+	s.testParseError(c, "", `storage constraints require at least one field to be specified`)
+	s.testParseError(c, ",", `storage constraints require at least one field to be specified`)
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsSizeRange(c *gc.C) {

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -21,7 +21,7 @@ const (
 	RootfsStorageDir = "storage-dir"
 )
 
-// rootfsProviders create volume sources which use loop devices.
+// rootfsProviders create volume sources which mount filesystems.
 type rootfsProvider struct {
 	run RunCommandFn
 }

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -21,7 +21,8 @@ const (
 	RootfsStorageDir = "storage-dir"
 )
 
-// rootfsProviders create volume sources which mount filesystems.
+// rootfsProvider implements a storage.Provider, providing "filesystems"
+// backed by directories on the root filesystem.
 type rootfsProvider struct {
 	run RunCommandFn
 }

--- a/storage/providerregistry_test.go
+++ b/storage/providerregistry_test.go
@@ -23,6 +23,10 @@ func (p *mockProvider) VolumeSource(*config.Config, *storage.Config) (storage.Vo
 	return nil, errors.New("not implemented")
 }
 
+func (p *mockProvider) FilesystemSource(*config.Config, *storage.Config) (storage.FilesystemSource, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (p *mockProvider) ValidateConfig(*storage.Config) error {
 	return nil
 }


### PR DESCRIPTION
Fix some tests.

Make default storage constraint size = 1G
Make default storage count = 1 regardless of size.