### PR TITLE
When storage id is not known, do not panic!

### DIFF
--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -257,8 +257,8 @@ func filterAttachment(machineSet set.Strings, attachment volume.Attachment) (par
 
 	size := attachment.Size()
 
-	storageTag := names.StorageTagKind + "-unknown/0"
-	if names.IsValidStorage(attachment.Storage()) {
+	storageTag := ""
+	if attachment.Storage() != "" {
 		storageTag = names.NewStorageTag(attachment.Storage()).String()
 	}
 	one := params.VolumeAttachment{

--- a/apiserver/storage/storage.go
+++ b/apiserver/storage/storage.go
@@ -256,12 +256,17 @@ func filterAttachment(machineSet set.Strings, attachment volume.Attachment) (par
 	}
 
 	size := attachment.Size()
+
+	storageTag := names.StorageTagKind + "-unknown/0"
+	if names.IsValidStorage(attachment.Storage()) {
+		storageTag = names.NewStorageTag(attachment.Storage()).String()
+	}
 	one := params.VolumeAttachment{
 		Volume:      attachment.Disk().String(),
 		Machine:     names.NewMachineTag(attachment.Machine()).String(),
 		DeviceName:  attachment.DeviceName(),
 		Size:        &size,
-		Storage:     names.NewStorageTag(attachment.Storage()).String(),
+		Storage:     storageTag,
 		Assigned:    attachment.Assigned(),
 		Attached:    attachment.Attached(),
 		FileSystem:  attachment.FilesystemType(),

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -74,11 +74,14 @@ func formatAttachmentInfo(all []params.VolumeAttachment) (map[string]AttachmentI
 	for _, one := range all {
 		// TODO (anastasiamac 2015-01-31) add similar logic for volume tags
 		// when available
-		storageTag, err := names.ParseStorageTag(one.Storage)
-		if err != nil {
-			return nil, errors.Annotate(err, "invalid storage tag")
+		storageName := ""
+		if one.Storage != "" {
+			storageTag, err := names.ParseStorageTag(one.Storage)
+			if err != nil {
+				return nil, errors.Annotate(err, "invalid storage tag")
+			}
+			storageName, _ = names.StorageName(storageTag.Id())
 		}
-		storageName, _ := names.StorageName(storageTag.Id())
 		machineTag, err := names.ParseTag(one.Machine)
 		if err != nil {
 			return nil, errors.Annotate(err, "invalid machine tag")


### PR DESCRIPTION
This is catering for volumes where we cannot determine storage id.

This fix produces:

$ juju storage volume list
VOLUME  ATTACHED  MACHINE  DEVICE NAME  SIZE    
disk-0  true      0        sda          466GiB  

$ juju storage volume list --format yaml
- attachments:
    disk-0:
      machine: "0"
      attached: true
      device-name: sda
      size: 477102
      provisioned: true

$ juju storage volume list --format json
[{"Attachments":{"disk-0":{"machine":"0","attached":true,"device-name":"sda","size":477102,"provisioned":true}}}]
