### PR TITLE
Add pluggable publisher for remote relation changes, plus RegisterRemoteRelation API

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -84,6 +84,24 @@ func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult
 	return results.Results, nil
 }
 
+// RegisterRemoteRelation sets up the local model to participate in the specified relation.
+func (c *Client) RegisterRemoteRelation(rel params.RegisterRemoteRelation) error {
+	args := params.RegisterRemoteRelations{Relations: []params.RegisterRemoteRelation{rel}}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
 func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
 	args := params.RelationUnits{relationUnits}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -314,3 +314,42 @@ func (s *remoteRelationsSuite) TestRemoteApplicationsResultsCount(c *gc.C) {
 	_, err := client.RemoteApplications([]string{"foo"})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelation(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RegisterRemoteRelations")
+		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
+			Relations: []params.RegisterRemoteRelation{{OfferedApplicationName: "offeredapp"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RegisterRemoteRelation(params.RegisterRemoteRelation{OfferedApplicationName: "offeredapp"})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RegisterRemoteRelation(params.RegisterRemoteRelation{})
+	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
+}

--- a/apiserver/application/application_test.go
+++ b/apiserver/application/application_test.go
@@ -2511,7 +2511,7 @@ func (s *serviceSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// And try to add it again.
 	_, err = s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
 }
 
 type mockApplicationOffersFactory struct {
@@ -2581,7 +2581,7 @@ func (s *serviceSuite) TestAlreadyAddedRemoteRelation(c *gc.C) {
 
 	// And try to add it again.
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{endpoints})
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db hosted-mysql:server": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db hosted-mysql:server": relation wordpress:db hosted-mysql:server already exists`)
 }
 
 func (s *serviceSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -399,3 +399,26 @@ type RemoteRelationChangeEvent struct {
 	// the relation since the last change.
 	DepartedUnits []RemoteEntityId `json:"departed-units,omitempty"`
 }
+
+// RegisterRemoteRelation holds attributes used to register a remote relation.
+type RegisterRemoteRelation struct {
+	// ApplicationId is the application id on the remote model.
+	ApplicationId RemoteEntityId `json:"application-id"`
+
+	// RelationId is the relation id on the remote model.
+	RelationId RemoteEntityId `json:"relation-id"`
+
+	// RemoteEndpoint contains info about the endpoint in the remote model.
+	RemoteEndpoint RemoteEndpoint `json:"remote-endpoint"`
+
+	// OfferedApplicationName is the name of the application offer from the local model.
+	OfferedApplicationName string `json:"offered-application-name"`
+
+	// LocalEndpointName is the name of the endpoint in the local model.
+	LocalEndpointName string `json:"local-endpoint-name"`
+}
+
+// RegisterRemoteRelations holds args used to add remote relations.
+type RegisterRemoteRelations struct {
+	Relations []RegisterRemoteRelation `json:"relations"`
+}

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -868,7 +868,7 @@ func (h *bundleHandler) upgradeCharm(
 func isErrServiceExists(err error) bool {
 	// TODO frankban (bug 1495952): do this check using the cause rather than
 	// the string when a specific cause is available.
-	return strings.HasSuffix(err.Error(), "application already exists")
+	return params.IsCodeAlreadyExists(err) || strings.HasSuffix(err.Error(), "application already exists")
 }
 
 // isErrRelationExists reports whether the given error has been generated
@@ -876,5 +876,5 @@ func isErrServiceExists(err error) bool {
 func isErrRelationExists(err error) bool {
 	// TODO frankban (bug 1495952): do this check using the cause rather than
 	// the string when a specific cause is available.
-	return strings.HasSuffix(err.Error(), "relation already exists")
+	return params.IsCodeAlreadyExists(err) || strings.HasSuffix(err.Error(), "relation already exists")
 }

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -53,6 +53,7 @@ var (
 		"status-history-pruner",
 		"storage-provisioner",
 		"unit-assigner",
+		"remote-relations",
 	}
 	migratingModelWorkers = []string{
 		"environ-tracker",

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -296,7 +296,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	}
 	if featureflag.Enabled(feature.CrossModelRelations) {
 		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
+			AgentName:                agentName,
 			APICallerName:            apiCallerName,
+			APIOpen:                  api.Open,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
 		}))

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -34,7 +34,7 @@ func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
 
 func (s *CmdRelationSuite) TestAddRelationFail(c *gc.C) {
 	runCommandExpectSuccess(c, "add-relation", s.apps...)
-	runCommandExpectFailure(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation already exists`, s.apps...)
+	runCommandExpectFailure(c, "add-relation", `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`, s.apps...)
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -143,9 +143,9 @@ func (s *RelationSuite) TestAddRelation(c *gc.C) {
 
 	// Check we cannot re-add the same relation, regardless of endpoint ordering.
 	_, err = s.State.AddRelation(mysqlEP, wordpressEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
 	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
 	assertOneRelation(c, mysql, 0, mysqlEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, mysqlEP)
 }
@@ -181,9 +181,9 @@ func (s *RelationSuite) TestAddContainerRelation(c *gc.C) {
 
 	// Check we cannot re-add the same relation, regardless of endpoint ordering.
 	_, err = s.State.AddRelation(loggingEP, wordpressEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info already exists`)
 	_, err = s.State.AddRelation(wordpressEP, loggingEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info already exists`)
 	assertOneRelation(c, logging, 0, loggingEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, loggingEP)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1654,7 +1654,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		if exists, err := isNotDead(st, relationsC, key); err != nil {
 			return nil, errors.Trace(err)
 		} else if exists {
-			return nil, errors.Errorf("relation already exists")
+			return nil, errors.AlreadyExistsf("relation %v", key)
 		}
 		// Collect per-application operations, checking sanity as we go.
 		var ops []txn.Op

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/remoterelations"
@@ -30,6 +31,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 	return remoterelations.ManifoldConfig{
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
+		APIOpen:                  func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 	}
@@ -57,6 +59,11 @@ func (s *ManifoldConfigSuite) TestMissingNewRemoteRelationsFacade(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 	s.config.NewWorker = nil
 	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPIOpen(c *gc.C) {
+	s.config.APIOpen = nil
+	s.checkNotValid(c, "nil APIOpen not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -39,6 +39,11 @@ func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
 	}
 }
 
+func (m *mockRelationsFacade) Close() error {
+	m.stub.MethodCall(m, "Close")
+	return nil
+}
+
 func (m *mockRelationsFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -41,6 +41,9 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	s.relationsFacade = newMockRelationsFacade(s.stub)
 	s.config = remoterelations.Config{
 		RelationsFacade: s.relationsFacade,
+		NewPublisherForModelFunc: func(modelUUID string) (remoterelations.RemoteRelationChangePublisherCloser, error) {
+			return s.relationsFacade, nil
+		},
 	}
 }
 
@@ -113,6 +116,7 @@ func (s *remoteRelationsSuite) TestRemoteApplicationRemoved(c *gc.C) {
 	c.Check(relWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
 		{"RemoteApplications", []interface{}{[]string{"django"}}},
+		{"Close", nil},
 	}
 	s.waitForStubCalls(c, expected)
 }

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -4,8 +4,14 @@
 package remoterelations
 
 import (
-	"github.com/juju/errors"
+	"io"
+	"time"
 
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/worker"
@@ -22,4 +28,58 @@ func NewWorker(config Config) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 	return w, nil
+}
+
+func apiConnForModelFunc(
+	a agent.Agent,
+	apiOpen func(*api.Info, api.DialOpts) (api.Connection, error),
+) (func(string) (api.Connection, error), error) {
+	agentConf := a.CurrentConfig()
+	apiInfo, ok := agentConf.APIInfo()
+	if !ok {
+		return nil, errors.New("no API connection details")
+	}
+	return func(modelUUID string) (api.Connection, error) {
+		apiInfo.ModelTag = names.NewModelTag(modelUUID)
+		conn, err := apiOpen(apiInfo, api.DialOpts{
+			Timeout:    time.Second,
+			RetryDelay: 200 * time.Millisecond,
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "failed to open API to remote model")
+		}
+		return conn, nil
+	}, nil
+}
+
+// relationChangePublisherForModelFunc returns a function that
+// can be used be construct instances which publish remote relation
+// changes for a given model.
+
+// For now we use a facade on the same controller, but in future this
+// may evolve into a REST caller.
+func relationChangePublisherForModelFunc(
+	apiConnForModelFunc func(string) (api.Connection, error),
+) func(string) (RemoteRelationChangePublisherCloser, error) {
+	return func(modelUUID string) (RemoteRelationChangePublisherCloser, error) {
+		conn, err := apiConnForModelFunc(modelUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		facade, err := NewRemoteRelationsFacade(conn)
+		if err != nil {
+			conn.Close()
+			return nil, errors.Trace(err)
+		}
+		return &publisherCloser{facade, conn}, nil
+	}
+}
+
+type publisherCloser struct {
+	RemoteRelationChangePublisher
+	conn io.Closer
+}
+
+func (p *publisherCloser) Close() error {
+	return p.Close()
 }


### PR DESCRIPTION
The remoterelation worker now has a plugable API implementation it can use to publish relations changes.
There's also a new RegisterRemoteRelation API which will be used for future work.