### PR TITLE
Add pluggable publisher for remote relation changes, plus RegisterRemoteRelation API

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -84,6 +84,24 @@ func (c *Client) ExportEntities(tags []names.Tag) ([]params.RemoteEntityIdResult
 	return results.Results, nil
 }
 
+// RegisterRemoteRelation sets up the local model to participate in the specified relation.
+func (c *Client) RegisterRemoteRelation(rel params.RegisterRemoteRelation) error {
+	args := params.RegisterRemoteRelations{Relations: []params.RegisterRemoteRelation{rel}}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.
 func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]params.SettingsResult, error) {
 	args := params.RelationUnits{relationUnits}

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -118,12 +118,12 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RelationUnit) ([]pa
 
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (c *Client) Relations(keys []string) ([]params.RelationResult, error) {
+func (c *Client) Relations(keys []string) ([]params.RemoteRelation, error) {
 	args := params.Entities{Entities: make([]params.Entity, len(keys))}
 	for i, key := range keys {
 		args.Entities[i].Tag = names.NewRelationTag(key).String()
 	}
-	var results params.RelationResults
+	var results params.RemoteRelationResults
 	err := c.facade.FacadeCall("Relations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -314,3 +314,42 @@ func (s *remoteRelationsSuite) TestRemoteApplicationsResultsCount(c *gc.C) {
 	_, err := client.RemoteApplications([]string{"foo"})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelation(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "RemoteRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RegisterRemoteRelations")
+		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
+			Relations: []params.RegisterRemoteRelation{{OfferedApplicationName: "offeredapp"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RegisterRemoteRelation(params.RegisterRemoteRelation{OfferedApplicationName: "offeredapp"})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := remoterelations.NewClient(apiCaller)
+	err := client.RegisterRemoteRelation(params.RegisterRemoteRelation{})
+	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
+}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -243,9 +243,9 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "Relations")
 		c.Check(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "relation-foo.db#bar.db"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RelationResults{})
-		*(result.(*params.RelationResults)) = params.RelationResults{
-			Results: []params.RelationResult{{
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteRelationResults{})
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelation{{
 				Error: &params.Error{Message: "FAIL"},
 			}},
 		}
@@ -262,8 +262,8 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 
 func (s *remoteRelationsSuite) TestRelationsResultsCount(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RelationResults)) = params.RelationResults{
-			Results: []params.RelationResult{
+		*(result.(*params.RemoteRelationResults)) = params.RemoteRelationResults{
+			Results: []params.RemoteRelation{
 				{Error: &params.Error{Message: "FAIL"}},
 				{Error: &params.Error{Message: "FAIL"}},
 			},

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -399,3 +399,26 @@ type RemoteRelationChangeEvent struct {
 	// the relation since the last change.
 	DepartedUnits []RemoteEntityId `json:"departed-units,omitempty"`
 }
+
+// RegisterRemoteRelation holds attributes used to register a remote relation.
+type RegisterRemoteRelation struct {
+	// ApplicationId is the application id on the remote model.
+	ApplicationId RemoteEntityId `json:"application-id"`
+
+	// RelationId is the relation id on the remote model.
+	RelationId RemoteEntityId `json:"relation-id"`
+
+	// RemoteEndpoint contains info about the endpoint in the remote model.
+	RemoteEndpoint RemoteEndpoint `json:"remote-endpoint"`
+
+	// OfferedApplicationName is the name of the application offer from the local model.
+	OfferedApplicationName string `json:"offered-application-name"`
+
+	// LocalEndpointName is the name of the endpoint in the local model.
+	LocalEndpointName string `json:"local-endpoint-name"`
+}
+
+// RegisterRemoteRelations holds args used to add remote relations.
+type RegisterRemoteRelations struct {
+	Relations []RegisterRemoteRelation `json:"relations"`
+}

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -246,19 +246,18 @@ type RemoteEntityIdResults struct {
 // RemoteRelation describes the current state of a cross-model relation from
 // the perspective of the local model.
 type RemoteRelation struct {
-	Id   RemoteEntityId `json:"id"`
-	Life Life           `json:"life"`
+	Error              *Error         `json:"error,omitempty"`
+	Life               Life           `json:"life"`
+	Id                 int            `json:"id"`
+	Key                string         `json:"key"`
+	LocalEndpoint      RemoteEndpoint `json:"local-endpoint"`
+	RemoteEndpointName string         `json:"remote-endpoint-name"`
 }
 
-// RemoteRelationResult holds a remote relation and an error.
-type RemoteRelationResult struct {
-	Result *RemoteRelation `json:"result,omitempty"`
-	Error  *Error          `json:"error,omitempty"`
-}
-
-// RemoteRelationResults holds a set of remote relation results.
+// RemoteRelationResults holds the result of an API call that returns
+// information about multiple remote relations.
 type RemoteRelationResults struct {
-	Results []RemoteRelationResult `json:"results,omitempty"`
+	Results []RemoteRelation `json:"results"`
 }
 
 // RemoteApplication describes the current state of an application involved in a cross-
@@ -275,6 +274,10 @@ type RemoteApplication struct {
 
 	// ModelUUID is the UUId of the model hosting the application.
 	ModelUUID string `json:"model-uuid"`
+	
+	// Registered returns the application is created
+	// from a registration operation by a consuming model.	
+	Registered bool `json:"registered"`
 }
 
 // RemoteApplicationResult holds a remote application and an error.

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -4,8 +4,11 @@
 package remoterelations_test
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
@@ -23,7 +26,7 @@ type mockState struct {
 	applications                 map[string]*mockApplication
 	remoteApplicationsWatcher    *mockStringsWatcher
 	applicationRelationsWatchers map[string]*mockStringsWatcher
-	exportedEntities             map[string]string
+	remoteEntities               map[string]string
 }
 
 func newMockState() *mockState {
@@ -33,7 +36,7 @@ func newMockState() *mockState {
 		applications:                 make(map[string]*mockApplication),
 		remoteApplicationsWatcher:    newMockStringsWatcher(),
 		applicationRelationsWatchers: make(map[string]*mockStringsWatcher),
-		exportedEntities:             make(map[string]string),
+		remoteEntities:               make(map[string]string),
 	}
 }
 
@@ -41,16 +44,41 @@ func (st *mockState) ModelUUID() string {
 	return coretesting.ModelTag.Id()
 }
 
+func (st *mockState) AddRelation(eps ...state.Endpoint) (remoterelations.Relation, error) {
+	rel := &mockRelation{
+		key: fmt.Sprintf("%v:%v %v:%v", eps[0].ApplicationName, eps[0].Name, eps[1].ApplicationName, eps[1].Name)}
+	st.relations[rel.key] = rel
+	return rel, nil
+}
+
+func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParams) (remoterelations.RemoteApplication, error) {
+	app := &mockRemoteApplication{name: params.Name, eps: params.Endpoints}
+	st.remoteApplications[params.Name] = app
+	return app, nil
+}
+
+func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error {
+	st.MethodCall(st, "ImportRemoteEntity", sourceModel, entity, token)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	if _, ok := st.remoteEntities[entity.Id()]; ok {
+		return errors.AlreadyExistsf(entity.Id())
+	}
+	st.remoteEntities[entity.Id()] = token
+	return nil
+}
+
 func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
 	st.MethodCall(st, "ExportLocalEntity", entity)
 	if err := st.NextErr(); err != nil {
 		return "", err
 	}
-	if token, ok := st.exportedEntities[entity.Id()]; ok {
+	if token, ok := st.remoteEntities[entity.Id()]; ok {
 		return token, errors.AlreadyExistsf(entity.Id())
 	}
 	token := "token-" + entity.Id()
-	st.exportedEntities[entity.Id()] = token
+	st.remoteEntities[entity.Id()] = token
 	return token, nil
 }
 
@@ -139,6 +167,7 @@ func (st *mockState) WatchRemoteApplicationRelations(applicationName string) (st
 type mockRelation struct {
 	testing.Stub
 	id                    int
+	key                   string
 	life                  state.Life
 	units                 map[string]remoterelations.RelationUnit
 	endpoints             []state.Endpoint
@@ -157,6 +186,11 @@ func newMockRelation(id int) *mockRelation {
 func (r *mockRelation) Id() int {
 	r.MethodCall(r, "Id")
 	return r.id
+}
+
+func (r *mockRelation) Tag() names.Tag {
+	r.MethodCall(r, "Tag")
+	return names.NewRelationTag(r.key)
 }
 
 func (r *mockRelation) Life() state.Life {
@@ -216,6 +250,7 @@ type mockRemoteApplication struct {
 	url    string
 	life   state.Life
 	status status.Status
+	eps    []charm.Relation
 }
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
@@ -227,6 +262,11 @@ func newMockRemoteApplication(name, url string) *mockRemoteApplication {
 func (r *mockRemoteApplication) Name() string {
 	r.MethodCall(r, "Name")
 	return r.name
+}
+
+func (r *mockRemoteApplication) Tag() names.Tag {
+	r.MethodCall(r, "Tag")
+	return names.NewApplicationTag(r.name)
 }
 
 func (r *mockRemoteApplication) Life() state.Life {
@@ -258,6 +298,7 @@ type mockApplication struct {
 	testing.Stub
 	name string
 	life state.Life
+	eps  []state.Endpoint
 }
 
 func newMockApplication(name string) *mockApplication {
@@ -266,14 +307,24 @@ func newMockApplication(name string) *mockApplication {
 	}
 }
 
-func (r *mockApplication) Name() string {
-	r.MethodCall(r, "Name")
-	return r.name
+func (a *mockApplication) Name() string {
+	a.MethodCall(a, "Name")
+	return a.name
 }
 
-func (r *mockApplication) Life() state.Life {
-	r.MethodCall(r, "Life")
-	return r.life
+func (a *mockApplication) Tag() names.Tag {
+	a.MethodCall(a, "Tag")
+	return names.NewApplicationTag(a.name)
+}
+
+func (a *mockApplication) Endpoints() ([]state.Endpoint, error) {
+	a.MethodCall(a, "Endpoints")
+	return a.eps, nil
+}
+
+func (a *mockApplication) Life() state.Life {
+	a.MethodCall(a, "Life")
+	return a.life
 }
 
 type mockWatcher struct {

--- a/apiserver/remoterelations/mock_test.go
+++ b/apiserver/remoterelations/mock_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remoterelations"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 	coretesting "github.com/juju/juju/testing"
@@ -40,6 +41,14 @@ func newMockState() *mockState {
 	}
 }
 
+func (st *mockState) ListOffers(filter ...crossmodel.OfferedApplicationFilter) ([]crossmodel.OfferedApplication, error) {
+	result := make([]crossmodel.OfferedApplication, len(filter))
+	for i, f := range filter {
+		result[i] = crossmodel.OfferedApplication{CharmName: "application-" + f.ApplicationName}
+	}
+	return result, nil
+}
+
 func (st *mockState) ModelUUID() string {
 	return coretesting.ModelTag.Id()
 }
@@ -52,7 +61,7 @@ func (st *mockState) AddRelation(eps ...state.Endpoint) (remoterelations.Relatio
 }
 
 func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParams) (remoterelations.RemoteApplication, error) {
-	app := &mockRemoteApplication{name: params.Name, eps: params.Endpoints}
+	app := &mockRemoteApplication{name: params.Name, eps: params.Endpoints, registered: params.Registered}
 	st.remoteApplications[params.Name] = app
 	return app, nil
 }
@@ -246,11 +255,12 @@ func (r *mockRelation) WatchUnits(applicationName string) (state.RelationUnitsWa
 
 type mockRemoteApplication struct {
 	testing.Stub
-	name   string
-	url    string
-	life   state.Life
-	status status.Status
-	eps    []charm.Relation
+	name       string
+	url        string
+	life       state.Life
+	status     status.Status
+	eps        []charm.Relation
+	registered bool
 }
 
 func newMockRemoteApplication(name, url string) *mockRemoteApplication {
@@ -267,6 +277,11 @@ func (r *mockRemoteApplication) Name() string {
 func (r *mockRemoteApplication) Tag() names.Tag {
 	r.MethodCall(r, "Tag")
 	return names.NewApplicationTag(r.name)
+}
+
+func (r *mockRemoteApplication) Registered() bool {
+	r.MethodCall(r, "Registered")
+	return r.registered
 }
 
 func (r *mockRemoteApplication) Life() state.Life {

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -4,9 +4,12 @@
 package remoterelations
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/set"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 	"gopkg.in/tomb.v1"
 
@@ -286,10 +289,106 @@ func (api *RemoteRelationsAPI) ConsumeRemoteApplicationChange(
 
 // PublishLocalRelationChange publishes local relations changes to the
 // remote side offering those relations.
-func (api *RemoteRelationsAPI) PublishLocalRelationsChange(
+func (api *RemoteRelationsAPI) PublishLocalRelationChange(
 	changes params.RemoteRelationsChanges,
 ) (params.ErrorResults, error) {
 	return params.ErrorResults{}, errors.NotImplementedf("PublishLocalRelationChange")
+}
+
+// RegisterRemoteRelations sets up the local model to participate
+// in the specified relations. This operation is idempotent.
+func (api *RemoteRelationsAPI) RegisterRemoteRelations(
+	relations params.RegisterRemoteRelations,
+) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(relations.Relations)),
+	}
+	for i, relation := range relations.Relations {
+		if err := api.registerRemoteRelation(relation); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+	return results, nil
+}
+
+func (api *RemoteRelationsAPI) registerRemoteRelation(relation params.RegisterRemoteRelation) error {
+	// TODO(wallyworld) - do this as a transaction so the result is atomic
+	// Perform some initial validation - is the local application alive?
+
+	// TODO(wallyworld) - look up local name from offered name
+	localApplicationName := relation.OfferedApplicationName
+
+	localApp, err := api.st.Application(localApplicationName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if localApp.Life() != state.Alive {
+		return errors.NotFoundf("application %v", localApplicationName)
+	}
+	eps, err := localApp.Endpoints()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Does the requested local endpoint exist?
+	var localEndpoint *state.Endpoint
+	for _, ep := range eps {
+		if ep.Name == relation.LocalEndpointName {
+			localEndpoint = &ep
+			break
+		}
+	}
+	if localEndpoint == nil {
+		return errors.NotFoundf("relation endpoint %v", relation.LocalEndpointName)
+	}
+
+	// Add the remote application reference. We construct a unique, opaque application name based on the
+	// token passed in from the consuming model. This model, which is offering the application being
+	// related to, does not need to know the name of the consuming application.
+	uniqueRemoteApplicationName := "remote-" + strings.Replace(relation.ApplicationId.Token, "-", "", -1)
+	remoteEndpoint := state.Endpoint{
+		ApplicationName: uniqueRemoteApplicationName,
+		Relation: charm.Relation{
+			Name:      relation.RemoteEndpoint.Name,
+			Scope:     relation.RemoteEndpoint.Scope,
+			Interface: relation.RemoteEndpoint.Interface,
+			Role:      relation.RemoteEndpoint.Role,
+			Limit:     relation.RemoteEndpoint.Limit,
+		},
+	}
+
+	remoteModelTag := names.NewModelTag(relation.ApplicationId.ModelUUID)
+	app, err := api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        uniqueRemoteApplicationName,
+		SourceModel: names.NewModelTag(relation.ApplicationId.ModelUUID),
+		Token:       relation.ApplicationId.Token,
+		Endpoints:   []charm.Relation{remoteEndpoint.Relation},
+	})
+	// If it already exists, that's fine.
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return errors.Annotatef(err, "adding remote application %v", uniqueRemoteApplicationName)
+	}
+	logger.Debugf("added remote application %v to local model", uniqueRemoteApplicationName)
+
+	// Now add the relation.
+	localRel, err := api.st.AddRelation(*localEndpoint, remoteEndpoint)
+	// Again, if it already exists, that's fine.
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return errors.Annotate(err, "adding remote relation")
+	}
+	logger.Debugf("added remote relation %v to local environment", localRel.Id())
+
+	// Ensure we have references recorded.
+	err = api.st.ImportRemoteEntity(remoteModelTag, app.Tag(), relation.ApplicationId.Token)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return errors.Annotatef(err, "importing remote application %v to local model", uniqueRemoteApplicationName)
+	}
+	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
+	}
+	return nil
 }
 
 // WatchRemoteApplications starts a strings watcher that notifies of the addition,

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -137,24 +138,49 @@ func (api *RemoteRelationsAPI) RelationUnitSettings(relationUnits params.Relatio
 
 // Relations returns information about the cross-model relations with the specified keys
 // in the local model.
-func (api *RemoteRelationsAPI) Relations(entities params.Entities) (params.RelationResults, error) {
-	results := params.RelationResults{
-		Results: make([]params.RelationResult, len(entities.Entities)),
+func (api *RemoteRelationsAPI) Relations(entities params.Entities) (params.RemoteRelationResults, error) {
+	results := params.RemoteRelationResults{
+		Results: make([]params.RemoteRelation, len(entities.Entities)),
 	}
-	one := func(entity params.Entity) (params.RelationResult, error) {
+	one := func(entity params.Entity) (params.RemoteRelation, error) {
 		tag, err := names.ParseRelationTag(entity.Tag)
 		if err != nil {
-			return params.RelationResult{}, errors.Trace(err)
+			return params.RemoteRelation{}, errors.Trace(err)
 		}
 		rel, err := api.st.KeyRelation(tag.Id())
 		if err != nil {
-			return params.RelationResult{}, errors.Trace(err)
+			return params.RemoteRelation{}, errors.Trace(err)
 		}
-		return params.RelationResult{
+		result := params.RemoteRelation{
 			Id:   rel.Id(),
 			Life: params.Life(rel.Life().String()),
 			Key:  tag.Id(),
-		}, nil
+		}
+		for _, ep := range rel.Endpoints() {
+			// Try looking up the info for the remote application.
+			_, err := api.st.RemoteApplication(ep.ApplicationName)
+			if err != nil && !errors.IsNotFound(err) {
+				return params.RemoteRelation{}, errors.Trace(err)
+			} else if err == nil {
+				result.RemoteEndpointName = ep.Name
+				continue
+			}
+			// Try looking up the info for the local application.
+			_, err = api.st.Application(ep.ApplicationName)
+			if err != nil && !errors.IsNotFound(err) {
+				return params.RemoteRelation{}, errors.Trace(err)
+			} else if err == nil {
+				result.LocalEndpoint = params.RemoteEndpoint{
+					Name:      ep.Name,
+					Interface: ep.Interface,
+					Role:      ep.Role,
+					Scope:     ep.Scope,
+					Limit:     ep.Limit,
+				}
+				continue
+			}
+		}
+		return result, nil
 	}
 	for i, entity := range entities.Entities {
 		remoteRelation, err := one(entity)
@@ -187,10 +213,11 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 			return nil, errors.Trace(err)
 		}
 		return &params.RemoteApplication{
-			Name:      remoteApp.Name(),
-			Life:      params.Life(remoteApp.Life().String()),
-			Status:    status.Status.String(),
-			ModelUUID: remoteApp.SourceModel().Id(),
+			Name:       remoteApp.Name(),
+			Life:       params.Life(remoteApp.Life().String()),
+			Status:     status.Status.String(),
+			ModelUUID:  remoteApp.SourceModel().Id(),
+			Registered: remoteApp.Registered(),
 		}, nil
 	}
 	for i, entity := range entities.Entities {
@@ -316,8 +343,20 @@ func (api *RemoteRelationsAPI) registerRemoteRelation(relation params.RegisterRe
 	// TODO(wallyworld) - do this as a transaction so the result is atomic
 	// Perform some initial validation - is the local application alive?
 
-	// TODO(wallyworld) - look up local name from offered name
+	// The name the consuming side knows the application by is not necessarily
+	// what it has been deployed as locally.
 	localApplicationName := relation.OfferedApplicationName
+	appOffer, err := api.st.ListOffers(crossmodel.OfferedApplicationFilter{ApplicationName: relation.OfferedApplicationName})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(appOffer) == 0 {
+		// TODO(wallyworld) - we don't yet record the offer
+		// return errors.NotFoundf("offered application %q", relation.OfferedApplicationName)
+	} else {
+		// TODO(wallyworld) - charm name should be service name
+		localApplicationName = appOffer[0].CharmName
+	}
 
 	localApp, err := api.st.Application(localApplicationName)
 	if err != nil {
@@ -364,6 +403,7 @@ func (api *RemoteRelationsAPI) registerRemoteRelation(relation params.RegisterRe
 		SourceModel: names.NewModelTag(relation.ApplicationId.ModelUUID),
 		Token:       relation.ApplicationId.Token,
 		Endpoints:   []charm.Relation{remoteEndpoint.Relation},
+		Registered:  true,
 	})
 	// If it already exists, that's fine.
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -500,26 +500,62 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 	djangoRelationUnit.settings["key"] = "value"
 	db2Relation := newMockRelation(123)
 	db2Relation.units["django/0"] = djangoRelationUnit
+	db2Relation.endpoints = []state.Endpoint{
+		{
+			ApplicationName: "django",
+			Relation: charm.Relation{
+				Name:      "db",
+				Interface: "db2",
+				Role:      "provides",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		}, {
+			ApplicationName: "db2",
+			Relation: charm.Relation{
+				Name:      "data",
+				Interface: "db2",
+				Role:      "requires",
+				Limit:     1,
+				Scope:     charm.ScopeGlobal,
+			},
+		},
+	}
 	s.st.relations["db2:db django:db"] = db2Relation
+	app := newMockApplication("django")
+	s.st.applications["django"] = app
+	remoteApp := newMockRemoteApplication("db2", "url")
+	s.st.remoteApplications["db2"] = remoteApp
 	result, err := s.api.Relations(params.Entities{Entities: []params.Entity{{Tag: "relation-db2.db#django.db"}}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, jc.DeepEquals, []params.RelationResult{{
-		Id:   123,
-		Life: "alive",
-		Key:  "db2:db django:db",
+	c.Assert(result.Results, jc.DeepEquals, []params.RemoteRelation{{
+		Id:                 123,
+		Life:               "alive",
+		Key:                "db2:db django:db",
+		RemoteEndpointName: "data",
+		LocalEndpoint: params.RemoteEndpoint{
+			Name:      "db",
+			Role:      "provides",
+			Interface: "db2",
+			Limit:     1,
+			Scope:     "global",
+		},
 	}})
 	s.st.CheckCalls(c, []testing.StubCall{
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
+		{"RemoteApplication", []interface{}{"django"}},
+		{"Application", []interface{}{"django"}},
+		{"RemoteApplication", []interface{}{"db2"}},
 	})
 }
 
 func (s *remoteRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
-	app := newMockApplication("offeredapp")
+	app := newMockApplication("application-offeredapp")
 	app.eps = []state.Endpoint{{
-		ApplicationName: "offeredapp",
+		ApplicationName: "application-offeredapp",
 		Relation:        charm.Relation{Name: "local"},
 	}}
-	s.st.applications["offeredapp"] = app
+	s.st.applications["application-offeredapp"] = app
 	result, err := s.api.RegisterRemoteRelations(params.RegisterRemoteRelations{
 		Relations: []params.RegisterRemoteRelation{{
 			ApplicationId:          params.RemoteEntityId{ModelUUID: "model-uuid", Token: "app-token"},
@@ -533,15 +569,16 @@ func (s *remoteRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
 	expectedRemoteApp := s.st.remoteApplications["remote-apptoken"]
 	expectedRemoteApp.Stub = testing.Stub{} // don't care about api calls
 	c.Check(expectedRemoteApp, jc.DeepEquals, &mockRemoteApplication{
-		name: "remote-apptoken",
-		eps:  []charm.Relation{{Name: "remote"}},
+		name:       "remote-apptoken",
+		eps:        []charm.Relation{{Name: "remote"}},
+		registered: true,
 	})
-	expectedRel := s.st.relations["offeredapp:local remote-apptoken:remote"]
+	expectedRel := s.st.relations["application-offeredapp:local remote-apptoken:remote"]
 	expectedRel.Stub = testing.Stub{} // don't care about api calls
-	c.Check(expectedRel, jc.DeepEquals, &mockRelation{key: "offeredapp:local remote-apptoken:remote"})
+	c.Check(expectedRel, jc.DeepEquals, &mockRelation{key: "application-offeredapp:local remote-apptoken:remote"})
 	c.Check(s.st.remoteEntities, gc.HasLen, 2)
 	c.Check(s.st.remoteEntities["remote-apptoken"], gc.Equals, "app-token")
-	c.Check(s.st.remoteEntities["offeredapp:local remote-apptoken:remote"], gc.Equals, "rel-token")
+	c.Check(s.st.remoteEntities["application-offeredapp:local remote-apptoken:remote"], gc.Equals, "rel-token")
 }
 
 func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -22,8 +22,15 @@ type RemoteRelationsState interface {
 	// be derived unambiguously from the relation's endpoints).
 	KeyRelation(string) (Relation, error)
 
+	// AddRelation adds a relation between the specified endpoints and returns the relation info.
+	AddRelation(...state.Endpoint) (Relation, error)
+
 	// Relation returns the existing relation with the given id.
 	Relation(int) (Relation, error)
+
+	// AddRemoteApplication creates a new remote application record, having the supplied relation endpoints,
+	// with the supplied name (which must be unique across all applications, local and remote).
+	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
 
 	// RemoteApplication returns a remote application by name.
 	RemoteApplication(string) (RemoteApplication, error)
@@ -32,7 +39,7 @@ type RemoteRelationsState interface {
 	Application(string) (Application, error)
 
 	// WatchRemoteApplications returns a StringsWatcher that notifies of changes to
-	// the lifecycles of the remote applications in the environment.
+	// the lifecycles of the remote applications in the model.
 	WatchRemoteApplications() state.StringsWatcher
 
 	// WatchRemoteApplicationRelations returns a StringsWatcher that notifies of
@@ -49,6 +56,10 @@ type RemoteRelationsState interface {
 	// token and model.
 	GetRemoteEntity(names.ModelTag, string) (names.Tag, error)
 
+	// ImportRemoteEntity adds an entity to the remote entities collection
+	// with the specified opaque token.
+	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
+
 	// GetToken returns the token associated with the entity with the given tag
 	// and model.
 	GetToken(names.ModelTag, names.Tag) (string, error)
@@ -62,6 +73,9 @@ type Relation interface {
 
 	// Id returns the integer internal relation key.
 	Id() int
+
+	// Tag returns the relation's tag.
+	Tag() names.Tag
 
 	// Life returns the relation's current life state.
 	Life() state.Life
@@ -109,10 +123,13 @@ type RelationUnit interface {
 }
 
 // RemoteApplication represents the state of an application hosted in an external
-// (remote) environment.
+// (remote) model.
 type RemoteApplication interface {
 	// Name returns the name of the remote application.
 	Name() string
+
+	// Tag returns the remote applications's tag.
+	Tag() names.Tag
 
 	// SourceModel returns the tag of the model hosting the remote application.
 	SourceModel() names.ModelTag
@@ -127,10 +144,13 @@ type RemoteApplication interface {
 	Status() (status.StatusInfo, error)
 }
 
-// Application represents the state of a application hosted in the local environment.
+// Application represents the state of a application hosted in the local model.
 type Application interface {
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
+
+	// Endpoints returns the application's currently available relation endpoints.
+	Endpoints() ([]state.Endpoint, error)
 }
 
 type stateShim struct {
@@ -142,14 +162,19 @@ func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
 	return r.ExportLocalEntity(entity)
 }
 
-func (st stateShim) GetRemoteEntity(env names.ModelTag, token string) (names.Tag, error) {
+func (st stateShim) GetRemoteEntity(model names.ModelTag, token string) (names.Tag, error) {
 	r := st.State.RemoteEntities()
-	return r.GetRemoteEntity(env, token)
+	return r.GetRemoteEntity(model, token)
 }
 
-func (st stateShim) GetToken(env names.ModelTag, entity names.Tag) (string, error) {
+func (st stateShim) ImportRemoteEntity(model names.ModelTag, entity names.Tag, token string) error {
 	r := st.State.RemoteEntities()
-	return r.GetToken(env, entity)
+	return r.ImportRemoteEntity(model, entity, token)
+}
+
+func (st stateShim) GetToken(model names.ModelTag, entity names.Tag) (string, error) {
+	r := st.State.RemoteEntities()
+	return r.GetToken(model, entity)
 }
 
 func (st stateShim) KeyRelation(key string) (Relation, error) {
@@ -168,8 +193,24 @@ func (st stateShim) Relation(id int) (Relation, error) {
 	return relationShim{r, st.State}, nil
 }
 
+func (st stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.AddRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
 func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
 	a, err := st.State.RemoteApplication(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &remoteApplicationShim{a}, nil
+}
+
+func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) (RemoteApplication, error) {
+	a, err := st.State.AddRemoteApplication(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/remoterelations/state.go
+++ b/apiserver/remoterelations/state.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/status"
 )
@@ -63,6 +64,9 @@ type RemoteRelationsState interface {
 	// GetToken returns the token associated with the entity with the given tag
 	// and model.
 	GetToken(names.ModelTag, names.Tag) (string, error)
+
+	// ListOffers returns the application offers matching any one of the filter terms.
+	ListOffers(filter ...crossmodel.OfferedApplicationFilter) ([]crossmodel.OfferedApplication, error)
 }
 
 // Relation provides access a relation in global state.
@@ -134,6 +138,10 @@ type RemoteApplication interface {
 	// SourceModel returns the tag of the model hosting the remote application.
 	SourceModel() names.ModelTag
 
+	// Registered returns the application is created
+	// from a registration operation by a consuming model.
+	Registered() bool
+
 	// URL returns the remote application URL, at which it is offered.
 	URL() (string, bool)
 
@@ -155,6 +163,11 @@ type Application interface {
 
 type stateShim struct {
 	*state.State
+}
+
+func (st stateShim) ListOffers(filter ...crossmodel.OfferedApplicationFilter) ([]crossmodel.OfferedApplication, error) {
+	oa := state.NewOfferedApplications(st.State)
+	return oa.ListOffers(filter...)
 }
 
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -296,7 +296,9 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	}
 	if featureflag.Enabled(feature.CrossModelRelations) {
 		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
+			AgentName:                agentName,
 			APICallerName:            apiCallerName,
+			APIOpen:                  api.Open,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
 		}))

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -136,16 +136,18 @@ func (s *RelationSuite) TestAddRelation(c *gc.C) {
 	mysql := s.AddTestingService(c, "mysql", s.AddTestingCharm(c, "mysql"))
 	mysqlEP, err := mysql.Endpoint("server")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
+	rel, err := s.State.AddRelation(wordpressEP, mysqlEP)
 	c.Assert(err, jc.ErrorIsNil)
 	assertOneRelation(c, mysql, 0, mysqlEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, mysqlEP)
 
 	// Check we cannot re-add the same relation, regardless of endpoint ordering.
-	_, err = s.State.AddRelation(mysqlEP, wordpressEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
-	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation already exists`)
+	rel2, err := s.State.AddRelation(mysqlEP, wordpressEP)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(rel, jc.DeepEquals, rel2)
+	rel2, err = s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(rel, jc.DeepEquals, rel2)
 	assertOneRelation(c, mysql, 0, mysqlEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, mysqlEP)
 }

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -36,6 +36,7 @@ type remoteApplicationDoc struct {
 	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
 	Life            Life                `bson:"life"`
 	RelationCount   int                 `bson:"relationcount"`
+	Registered      bool                `bson:"registered"`
 }
 
 // remoteEndpointDoc represents the internal state of a remote application endpoint in MongoDB.
@@ -74,6 +75,12 @@ func (s *RemoteApplication) IsRemote() bool {
 // SourceModel returns the tag of the model to which the application belongs.
 func (s *RemoteApplication) SourceModel() names.ModelTag {
 	return names.NewModelTag(s.doc.SourceModelUUID)
+}
+
+// Registered returns the application is created
+// from a registration operation by a consuming model.
+func (s *RemoteApplication) Registered() bool {
+	return s.doc.Registered
 }
 
 // Name returns the application name.
@@ -324,6 +331,10 @@ type AddRemoteApplicationParams struct {
 
 	// Endpoints describes the endpoints that the remote application implements.
 	Endpoints []charm.Relation
+
+	// Registered is true when a remote application is created as a result
+	// of a registration operation from a remote model.
+	Registered bool
 }
 
 // Validate returns an error if there's a problem with the
@@ -369,6 +380,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		SourceModelUUID: args.SourceModel.Id(),
 		URL:             args.URL,
 		Life:            Alive,
+		Registered:      args.Registered,
 	}
 	eps := make([]remoteEndpointDoc, len(args.Endpoints))
 	for i, ep := range args.Endpoints {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -264,10 +264,23 @@ func (s *remoteApplicationSuite) TestAddRemoteApplication(c *gc.C) {
 		Name: "foo", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsFalse)
 	foo, err = s.State.RemoteApplication("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsFalse)
 	c.Assert(foo.SourceModel().Id(), gc.Equals, s.State.ModelTag().Id())
+}
+
+func (s *remoteApplicationSuite) TestAddRemoteApplicationRegistered(c *gc.C) {
+	foo, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "foo", URL: "local:/u/me/foo", SourceModel: s.State.ModelTag(), Registered: true})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(foo.Registered(), jc.IsTrue)
+	foo, err = s.State.RemoteApplication("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(foo.Name(), gc.Equals, "foo")
+	c.Assert(foo.Registered(), jc.IsTrue)
 }
 
 func (s *remoteApplicationSuite) TestAddRemoteRelationWrongScope(c *gc.C) {

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/remoterelations"
@@ -30,6 +31,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 	return remoterelations.ManifoldConfig{
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
+		APIOpen:                  func(*api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 	}
@@ -57,6 +59,11 @@ func (s *ManifoldConfigSuite) TestMissingNewRemoteRelationsFacade(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 	s.config.NewWorker = nil
 	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingAPIOpen(c *gc.C) {
+	s.config.APIOpen = nil
+	s.checkNotValid(c, "nil APIOpen not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -39,6 +39,11 @@ func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
 	}
 }
 
+func (m *mockRelationsFacade) Close() error {
+	m.stub.MethodCall(m, "Close")
+	return nil
+}
+
 func (m *mockRelationsFacade) WatchRemoteApplications() (watcher.StringsWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -25,6 +25,7 @@ type mockRelationsFacade struct {
 	remoteApplicationRelationsWatchers map[string]*mockStringsWatcher
 	remoteApplications                 map[string]*mockRemoteApplication
 	relations                          map[string]*mockRelation
+	relationsEndpoints                 map[string]*relationEndpointInfo
 	relationsUnitsWatchers             map[string]*mockRelationUnitsWatcher
 }
 
@@ -33,6 +34,7 @@ func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
 		stub:                               stub,
 		remoteApplications:                 make(map[string]*mockRemoteApplication),
 		relations:                          make(map[string]*mockRelation),
+		relationsEndpoints:                 make(map[string]*relationEndpointInfo),
 		remoteApplicationsWatcher:          newMockStringsWatcher(),
 		remoteApplicationRelationsWatchers: make(map[string]*mockStringsWatcher),
 		relationsUnitsWatchers:             make(map[string]*mockRelationUnitsWatcher),
@@ -141,6 +143,15 @@ func (m *mockRelationsFacade) PublishLocalRelationChange(change params.RemoteRel
 	}
 	return nil
 }
+
+func (m *mockRelationsFacade) RegisterRemoteRelation(rel params.RegisterRemoteRelation) error {
+	m.stub.MethodCall(m, "RegisterRemoteRelation", rel)
+	if err := m.stub.NextErr(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.RemoteApplicationResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -153,10 +164,11 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 		if app, ok := m.remoteApplications[name]; ok {
 			result[i] = params.RemoteApplicationResult{
 				Result: &params.RemoteApplication{
-					Name:      app.name,
-					Life:      app.life,
-					Status:    app.status,
-					ModelUUID: app.modelUUID,
+					Name:       app.name,
+					Life:       app.life,
+					Status:     app.status,
+					ModelUUID:  app.modelUUID,
+					Registered: app.registered,
 				},
 			}
 		} else {
@@ -167,23 +179,33 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 	return result, nil
 }
 
-func (m *mockRelationsFacade) Relations(keys []string) ([]params.RelationResult, error) {
+type relationEndpointInfo struct {
+	localApplicationName string
+	localEndpoint        params.RemoteEndpoint
+	remoteEndpointName   string
+}
+
+func (m *mockRelationsFacade) Relations(keys []string) ([]params.RemoteRelation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stub.MethodCall(m, "Relations", keys)
 	if err := m.stub.NextErr(); err != nil {
 		return nil, err
 	}
-	result := make([]params.RelationResult, len(keys))
+	result := make([]params.RemoteRelation, len(keys))
 	for i, key := range keys {
 		if rel, ok := m.relations[key]; ok {
-			result[i] = params.RelationResult{
+			result[i] = params.RemoteRelation{
 				Id:   rel.id,
 				Life: rel.life,
 				Key:  keys[i],
 			}
+			if epInfo, ok := m.relationsEndpoints[key]; ok {
+				result[i].RemoteEndpointName = epInfo.remoteEndpointName
+				result[i].LocalEndpoint = epInfo.localEndpoint
+			}
 		} else {
-			result[i] = params.RelationResult{
+			result[i] = params.RemoteRelation{
 				Error: common.ServerError(errors.NotFoundf(key))}
 		}
 	}
@@ -254,11 +276,12 @@ func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
 
 type mockRemoteApplication struct {
 	testing.Stub
-	name      string
-	url       string
-	life      params.Life
-	status    string
-	modelUUID string
+	name       string
+	url        string
+	life       params.Life
+	status     string
+	modelUUID  string
+	registered bool
 }
 
 type mockRelationUnitsWatcher struct {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -29,6 +29,10 @@ type RemoteRelationChangePublisherCloser interface {
 // RemoteRelationChangePublisher instances publish local relation changes to the
 // model hosting the remote application involved in the relation
 type RemoteRelationChangePublisher interface {
+	// RegisterRemoteRelation sets up the local model to participate
+	// in the specified relation.
+	RegisterRemoteRelation(rel params.RegisterRemoteRelation) error
+
 	// PublishLocalRelationChange publishes local relation changes to the
 	// model hosting the remote application involved in the relation.
 	PublishLocalRelationChange(params.RemoteRelationChangeEvent) error
@@ -48,7 +52,7 @@ type RemoteRelationsFacade interface {
 
 	// Relations returns information about the relations
 	// with the specified keys in the local model.
-	Relations(keys []string) ([]params.RelationResult, error)
+	Relations(keys []string) ([]params.RemoteRelation, error)
 
 	// RemoteApplications returns the current state of the remote applications with
 	// the specified names in the local model.
@@ -184,6 +188,22 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		}
 		// A new remote application has appeared, start monitoring relations to it
 		// originating from the local model.
+		// First, export the application.
+		appTag := names.NewApplicationTag(name)
+		results, err := w.config.RelationsFacade.ExportEntities([]names.Tag{appTag})
+		if err != nil {
+			return errors.Annotatef(err, "exporting application %v", appTag)
+		}
+		if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
+			return errors.Annotatef(err, "exporting application %v", appTag)
+		}
+		// Record what we know so far - the other attributes of
+		// the relation info will be filled in later.
+		relationInfo := remoteRelationInfo{
+			applicationId:         *results[0].Result,
+			remoteApplicationName: name,
+		}
+
 		relationsWatcher, err := w.config.RelationsFacade.WatchRemoteApplicationRelations(name)
 		if errors.IsNotFound(err) {
 			if err := w.killApplicationWorker(name); err != nil {
@@ -196,7 +216,9 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		logger.Debugf("started watcher for remote application %q", name)
 		appWorker, err := newRemoteApplicationWorker(
 			relationsWatcher,
+			relationInfo,
 			result.Result.ModelUUID,
+			result.Result.Registered,
 			w.config.NewPublisherForModelFunc,
 			w.config.RelationsFacade,
 			&w.exportMutex,
@@ -227,7 +249,9 @@ func (w *Worker) killApplicationWorker(name string) error {
 type remoteApplicationWorker struct {
 	catacomb         catacomb.Catacomb
 	relationsWatcher watcher.StringsWatcher
+	relationInfo     remoteRelationInfo
 	modelUUID        string // uuid of the model hosting the remote application
+	registered       bool
 	relationChanges  chan params.RemoteRelationChangeEvent
 
 	exportMutex              *sync.Mutex
@@ -240,16 +264,27 @@ type relation struct {
 	ruw *relationUnitsWatcher
 }
 
+type remoteRelationInfo struct {
+	applicationId         params.RemoteEntityId
+	localEndpoint         params.RemoteEndpoint
+	remoteApplicationName string
+	remoteEndpointName    string
+}
+
 func newRemoteApplicationWorker(
 	relationsWatcher watcher.StringsWatcher,
+	relationInfo remoteRelationInfo,
 	modelUUID string,
+	registered bool,
 	newPublisherForModelFunc func(modelUUID string) (RemoteRelationChangePublisherCloser, error),
 	facade RemoteRelationsFacade,
 	exportMutex *sync.Mutex,
 ) (worker.Worker, error) {
 	w := &remoteApplicationWorker{
 		relationsWatcher:         relationsWatcher,
+		relationInfo:             relationInfo,
 		modelUUID:                modelUUID,
+		registered:               registered,
 		relationChanges:          make(chan params.RemoteRelationChangeEvent),
 		facade:                   facade,
 		exportMutex:              exportMutex,
@@ -297,7 +332,7 @@ func (w *remoteApplicationWorker) loop() error {
 			}
 			for i, result := range results {
 				key := change[i]
-				if err := w.relationChanged(key, result, relations); err != nil {
+				if err := w.relationChanged(key, result, relations, publisher); err != nil {
 					return errors.Annotatef(err, "handling change for relation %q", key)
 				}
 			}
@@ -320,7 +355,8 @@ func (w *remoteApplicationWorker) killRelationUnitWatcher(key string, relations 
 }
 
 func (w *remoteApplicationWorker) relationChanged(
-	key string, result params.RelationResult, relations map[string]*relation,
+	key string, result params.RemoteRelation, relations map[string]*relation,
+	publisher RemoteRelationChangePublisher,
 ) error {
 	logger.Debugf("relation %q changed: %+v", key, result)
 	if result.Error != nil {
@@ -335,6 +371,8 @@ func (w *remoteApplicationWorker) relationChanged(
 
 	// If we have previously started the watcher and the
 	// relation is now dead, stop the watcher.
+	var remoteRelationId params.RemoteEntityId
+	relationTag := names.NewRelationTag(key)
 	if r := relations[key]; r != nil {
 		r.Life = result.Life
 		if r.Life == params.Dead {
@@ -342,6 +380,16 @@ func (w *remoteApplicationWorker) relationChanged(
 		}
 		// Nothing to do, we have previously started the watcher.
 		return nil
+	} else if !w.registered {
+		// We have not seen the relation before, make
+		// sure it is registered on the remote side.
+		w.relationInfo.localEndpoint = result.LocalEndpoint
+		w.relationInfo.remoteEndpointName = result.RemoteEndpointName
+		var err error
+		remoteRelationId, err = w.registerRemoteRelation(relationTag, publisher)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// Start a watcher to track changes to the local units in the
@@ -352,7 +400,8 @@ func (w *remoteApplicationWorker) relationChanged(
 			return errors.Trace(err)
 		}
 		relationUnitsWatcher, err := newRelationUnitsWatcher(
-			names.NewRelationTag(key),
+			relationTag,
+			remoteRelationId,
 			localRelationUnitsWatcher,
 			w.relationChanges,
 			w.facade,
@@ -373,6 +422,34 @@ func (w *remoteApplicationWorker) relationChanged(
 	return nil
 }
 
+func (w *remoteApplicationWorker) registerRemoteRelation(
+	relationTag names.Tag, publisher RemoteRelationChangePublisher,
+) (params.RemoteEntityId, error) {
+	// Ensure the relation is exported first up.
+	results, err := w.facade.ExportEntities([]names.Tag{relationTag})
+	if err != nil {
+		return params.RemoteEntityId{}, errors.Annotatef(err, "exporting relation %v", relationTag)
+	}
+	if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
+		return params.RemoteEntityId{}, errors.Annotatef(err, "exporting relation %v", relationTag)
+	}
+	remoteRelationId := *results[0].Result
+
+	// This data goes to the remote model so we map local info
+	// from this model to the remote arg vales and visa versa.
+	arg := params.RegisterRemoteRelation{
+		ApplicationId:          w.relationInfo.applicationId,
+		RelationId:             remoteRelationId,
+		RemoteEndpoint:         w.relationInfo.localEndpoint,
+		OfferedApplicationName: w.relationInfo.remoteApplicationName,
+		LocalEndpointName:      w.relationInfo.remoteEndpointName,
+	}
+	if err := publisher.RegisterRemoteRelation(arg); err != nil {
+		return params.RemoteEntityId{}, errors.Trace(err)
+	}
+	return remoteRelationId, nil
+}
+
 // relationUnitsWatcher uses a watcher.RelationUnitsWatcher to listen
 // to changes to relation settings in the local model and converts
 // to a params.RemoteRelationChanges for export to a remote model.
@@ -391,6 +468,7 @@ type relationUnitsWatcher struct {
 
 func newRelationUnitsWatcher(
 	relationTag names.RelationTag,
+	remoteRelationId params.RemoteEntityId,
 	ruw watcher.RelationUnitsWatcher,
 	changes chan<- params.RemoteRelationChangeEvent,
 
@@ -398,12 +476,13 @@ func newRelationUnitsWatcher(
 	exportMutex *sync.Mutex,
 ) (*relationUnitsWatcher, error) {
 	w := &relationUnitsWatcher{
-		relationTag:   relationTag,
-		ruw:           ruw,
-		changes:       changes,
-		remoteUnitIds: make(map[string]params.RemoteEntityId),
-		facade:        facade,
-		exportMutex:   exportMutex,
+		relationTag:      relationTag,
+		remoteRelationId: remoteRelationId,
+		ruw:              ruw,
+		changes:          changes,
+		remoteUnitIds:    make(map[string]params.RemoteEntityId),
+		facade:           facade,
+		exportMutex:      exportMutex,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -424,16 +503,6 @@ func (w *relationUnitsWatcher) Wait() error {
 }
 
 func (w *relationUnitsWatcher) loop() error {
-	// Ensure the relation is exported first up.
-	results, err := w.facade.ExportEntities([]names.Tag{w.relationTag})
-	if err != nil {
-		return errors.Annotatef(err, "exporting relation %v", w.relationTag)
-	}
-	if results[0].Error != nil && !params.IsCodeAlreadyExists(results[0].Error) {
-		return errors.Annotatef(err, "exporting relation %v", w.relationTag)
-	}
-	w.remoteRelationId = *results[0].Result
-
 	var changes chan<- params.RemoteRelationChangeEvent
 	var event params.RemoteRelationChangeEvent
 	for {

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -41,6 +41,9 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	s.relationsFacade = newMockRelationsFacade(s.stub)
 	s.config = remoterelations.Config{
 		RelationsFacade: s.relationsFacade,
+		NewPublisherForModelFunc: func(modelUUID string) (remoterelations.RemoteRelationChangePublisherCloser, error) {
+			return s.relationsFacade, nil
+		},
 	}
 }
 
@@ -113,6 +116,7 @@ func (s *remoteRelationsSuite) TestRemoteApplicationRemoved(c *gc.C) {
 	c.Check(relWatcher.killed(), jc.IsTrue)
 	expected := []jujutesting.StubCall{
 		{"RemoteApplications", []interface{}{[]string{"django"}}},
+		{"Close", nil},
 	}
 	s.waitForStubCalls(c, expected)
 }

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -4,8 +4,14 @@
 package remoterelations
 
 import (
-	"github.com/juju/errors"
+	"io"
+	"time"
 
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/worker"
@@ -22,4 +28,58 @@ func NewWorker(config Config) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 	return w, nil
+}
+
+func apiConnForModelFunc(
+	a agent.Agent,
+	apiOpen func(*api.Info, api.DialOpts) (api.Connection, error),
+) (func(string) (api.Connection, error), error) {
+	agentConf := a.CurrentConfig()
+	apiInfo, ok := agentConf.APIInfo()
+	if !ok {
+		return nil, errors.New("no API connection details")
+	}
+	return func(modelUUID string) (api.Connection, error) {
+		apiInfo.ModelTag = names.NewModelTag(modelUUID)
+		conn, err := apiOpen(apiInfo, api.DialOpts{
+			Timeout:    time.Second,
+			RetryDelay: 200 * time.Millisecond,
+		})
+		if err != nil {
+			return nil, errors.Annotate(err, "failed to open API to remote model")
+		}
+		return conn, nil
+	}, nil
+}
+
+// relationChangePublisherForModelFunc returns a function that
+// can be used be construct instances which publish remote relation
+// changes for a given model.
+
+// For now we use a facade on the same controller, but in future this
+// may evolve into a REST caller.
+func relationChangePublisherForModelFunc(
+	apiConnForModelFunc func(string) (api.Connection, error),
+) func(string) (RemoteRelationChangePublisherCloser, error) {
+	return func(modelUUID string) (RemoteRelationChangePublisherCloser, error) {
+		conn, err := apiConnForModelFunc(modelUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		facade, err := NewRemoteRelationsFacade(conn)
+		if err != nil {
+			conn.Close()
+			return nil, errors.Trace(err)
+		}
+		return &publisherCloser{facade, conn}, nil
+	}
+}
+
+type publisherCloser struct {
+	RemoteRelationChangePublisher
+	conn io.Closer
+}
+
+func (p *publisherCloser) Close() error {
+	return p.Close()
 }


### PR DESCRIPTION
The remoterelation worker now has a plugable API implementation it can use to publish relations changes.
There's also a new RegisterRemoteRelation API which will be used for future work.
