### PR TITLE
add-relation command uses the new consume apis to create remote relations

### DIFF
--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -832,58 +832,11 @@ func (api *API) AddRelation(args params.AddRelation) (params.AddRelationResults,
 	if err := api.check.ChangeAllowed(); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
-
-	endpoints := make([]string, len(args.Endpoints))
-	// We may have a remote application passed in as the endpoint spec.
-	// We'll iterate the endpoints to check.
-	//isRemote := false
-	for i, ep := range args.Endpoints {
-		endpoints[i] = ep
-
-		// TODO(wallyworld) - re-implement when facade updates are done
-		//// If cross model relations not enabled, ignore remote endpoints.
-		//if !featureflag.Enabled(feature.CrossModelRelations) {
-		//	continue
-		//}
-		//
-		//// If the endpoint is not remote, skip it.
-		//// We first need to strip off any relation name
-		//// which may have been appended to the URL, then
-		//// we try parsing the URL.
-		//possibleURL := applicationUrlEndpointParse.ReplaceAllString(ep, "$url")
-		//relName := applicationUrlEndpointParse.ReplaceAllString(ep, "$relname")
-		//
-		//// If the URL parses, we need to look up the remote application
-		//// details and save to state.
-		//url, err := jujucrossmodel.ParseApplicationURL(possibleURL)
-		//if err != nil {
-		//	// Not a URL.
-		//	continue
-		//}
-		//// Save the remote application details into state.
-		//// TODO(wallyworld) - allow app name to be aliased
-		//alias := url.ApplicationName
-		//remoteApp, err := api.processRemoteApplication(url, alias)
-		//if err != nil {
-		//	return params.AddRelationResults{}, errors.Trace(err)
-		//}
-		//// The endpoint is named after the remote application name,
-		//// not the application name from the URL.
-		//endpoints[i] = remoteApp.Name()
-		//if relName != "" {
-		//	endpoints[i] = remoteApp.Name() + ":" + relName
-		//}
-		//isRemote = true
-	}
-	// If it's not a remote relation to another model then
-	// the user needs write access to the model.
-	//if !isRemote {
 	if err := api.checkCanWrite(); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
-	//}
 
-	inEps, err := api.backend.InferEndpoints(endpoints...)
+	inEps, err := api.backend.InferEndpoints(args.Endpoints...)
 	if err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
@@ -928,11 +881,6 @@ func (api *API) DestroyRelation(args params.DestroyRelation) error {
 	}
 	return rel.Destroy()
 }
-
-// TODO(wallyworld) - we'll use this when the ConsumeDetails API is added.
-// applicationUrlEndpointParse is used to split an application url and optional
-// relation name into url and relation name.
-//var applicationUrlEndpointParse = regexp.MustCompile("(?P<url>.*[/.][^:]*)(:(?P<relname>.*)$)?")
 
 // Consume adds remote applications to the model without creating any
 // relations.

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -5,6 +5,7 @@ package application_test
 
 import (
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/juju/errors"
@@ -20,7 +21,6 @@ import (
 	statestorage "github.com/juju/juju/state/storage"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
-	"strings"
 )
 
 type mockEnviron struct {

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
@@ -35,7 +36,7 @@ func (s *AddRelationSuite) SetUpTest(c *gc.C) {
 var _ = gc.Suite(&AddRelationSuite{})
 
 func (s *AddRelationSuite) runAddRelation(c *gc.C, args ...string) error {
-	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(NewMockStore())
 	_, err := cmdtesting.RunCommand(c, cmd, args...)
 	return err
@@ -84,7 +85,7 @@ func (s *AddRelationSuite) TestAddRelationUnauthorizedMentionsJujuGrant(c *gc.C)
 		Message: "permission denied",
 		Code:    params.CodeUnauthorized,
 	})
-	cmd := NewAddRelationCommandForTest(s.mockAPI)
+	cmd := NewAddRelationCommandForTest(s.mockAPI, s.mockAPI)
 	cmd.SetClientStore(NewMockStore())
 	ctx, _ := cmdtesting.RunCommand(c, cmd, "application1", "application2")
 	errString := strings.Replace(cmdtesting.Stderr(ctx), "\n", " ", -1)
@@ -109,4 +110,12 @@ func (s mockAddAPI) AddRelation(endpoints ...string) (*params.AddRelationResults
 func (s mockAddAPI) BestAPIVersion() int {
 	s.MethodCall(s, "BestAPIVersion")
 	return 2
+}
+
+func (mockAddAPI) Consume(params.ApplicationOffer, string, *macaroon.Macaroon) (string, error) {
+	return "", errors.New("unexpected method call: Consume")
+}
+
+func (mockAddAPI) GetConsumeDetails(string) (params.ConsumeOfferDetails, error) {
+	return params.ConsumeOfferDetails{}, errors.New("unexpected method call: GetConsumeDetails")
 }

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -47,10 +47,8 @@ func NewAddUnitCommandForTest(api serviceAddUnitAPI) cmd.Command {
 }
 
 // NewAddRelationCommandForTest returns an AddRelationCommand with the api provided as specified.
-func NewAddRelationCommandForTest(api ApplicationAddRelationAPI) modelcmd.ModelCommand {
-	cmd := &addRelationCommand{newAPIFunc: func() (ApplicationAddRelationAPI, error) {
-		return api, nil
-	}}
+func NewAddRelationCommandForTest(addAPI applicationAddRelationAPI, consumeAPI applicationConsumeDetailsAPI) modelcmd.ModelCommand {
+	cmd := &addRelationCommand{addRelationAPI: addAPI, consumeDetailsAPI: consumeAPI}
 	return modelcmd.Wrap(cmd)
 }
 


### PR DESCRIPTION
## Description of change

The relate command is updated to use the new consume apis to create remote relations.
This means that code in the application facade that used to do that is no longer needed.
A big chunk of obsolete code is deleted from the application facade, and tests refactored.
Tests which were previously skipped are reinstated.

## QA steps

$ juju bootstrap
$ juju deploy mysql
$ juju offer mysql:db
$ juju switch controller
$ juju deploy mediawiki
$ juju relate mediawiki:db admin/default.mysql

