### PR TITLE
Split the remote relations publication apis off the remote relations facade

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// Client provides access to the crossmodelrelations api facade.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient creates a new client-side CrossModelRelations facade.
+func NewClient(caller base.APICaller) *Client {
+	facadeCaller := base.NewFacadeCaller(caller, "CrossModelRelations")
+	return &Client{facadeCaller}
+}
+
+// PublishLocalRelationChange publishes local relations changes to the
+// remote side offering those relations.
+func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
+	args := params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationChangeEvent{change},
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return errors.Trace(result.Error)
+	}
+	return nil
+}
+
+// RegisterRemoteRelations sets up the local model to participate in the specified relations.
+func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
+	args := params.RegisterRemoteRelations{Relations: relations}
+	var results params.RemoteEntityIdResults
+	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != len(relations) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
+	}
+	return results.Results, nil
+}

--- a/api/crossmodelrelations/crossmodelrelations_test.go
+++ b/api/crossmodelrelations/crossmodelrelations_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/crossmodelrelations"
+	"github.com/juju/juju/apiserver/params"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&CrossModelRelationsSuite{})
+
+type CrossModelRelationsSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *CrossModelRelationsSuite) TestNewClient(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	c.Assert(client, gc.NotNil)
+}
+
+func (s *CrossModelRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CrossModelRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "PublishLocalRelationChange")
+		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
+			Changes: []params.RemoteRelationChangeEvent{{
+				DepartedUnits: []int{1}}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+		*(result.(*params.ErrorResults)) = params.ErrorResults{
+			Results: []params.ErrorResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	err := client.PublishLocalRelationChange(params.RemoteRelationChangeEvent{DepartedUnits: []int{1}})
+	c.Check(err, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *CrossModelRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
+	var callCount int
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CrossModelRelations")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "RegisterRemoteRelations")
+		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
+			Relations: []params.RegisterRemoteRelation{{OfferName: "offeredapp"}}})
+		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		callCount++
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{OfferName: "offeredapp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(result, gc.HasLen, 1)
+	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
+	c.Check(callCount, gc.Equals, 1)
+}
+
+func (s *CrossModelRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
+			Results: []params.RemoteEntityIdResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	client := crossmodelrelations.NewClient(apiCaller)
+	_, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+}

--- a/api/crossmodelrelations/package_test.go
+++ b/api/crossmodelrelations/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -29,6 +29,7 @@ var facadeVersions = map[string]int{
 	"Client":                       1,
 	"Cloud":                        1,
 	"Controller":                   3,
+	"CrossModelRelations":          1,
 	"Deployer":                     1,
 	"DiskManager":                  2,
 	"EntityWatcher":                2,

--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -26,27 +26,6 @@ func NewClient(caller base.APICaller) *Client {
 	return &Client{facadeCaller}
 }
 
-// PublishLocalRelationChange publishes local relations changes to the
-// remote side offering those relations.
-func (c *Client) PublishLocalRelationChange(change params.RemoteRelationChangeEvent) error {
-	args := params.RemoteRelationsChanges{
-		Changes: []params.RemoteRelationChangeEvent{change},
-	}
-	var results params.ErrorResults
-	err := c.facade.FacadeCall("PublishLocalRelationChange", args, &results)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return errors.Trace(result.Error)
-	}
-	return nil
-}
-
 // ImportRemoteEntity adds an entity to the remote entities collection
 // with the specified opaque token.
 func (c *Client) ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error {
@@ -126,20 +105,6 @@ func (c *Client) RemoveRemoteEntity(sourceModelUUID string, entity names.Tag) er
 		return errors.Trace(result.Error)
 	}
 	return nil
-}
-
-// RegisterRemoteRelations sets up the local model to participate in the specified relations.
-func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelation) ([]params.RemoteEntityIdResult, error) {
-	args := params.RegisterRemoteRelations{Relations: relations}
-	var results params.RemoteEntityIdResults
-	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != len(relations) {
-		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
-	}
-	return results.Results, nil
 }
 
 // RelationUnitSettings returns the relation unit settings for the given relation units in the local model.

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -101,32 +101,6 @@ func (s *remoteRelationsSuite) TestWatchLocalRelationUnits(c *gc.C) {
 	c.Check(callCount, gc.Equals, 1)
 }
 
-func (s *remoteRelationsSuite) TestPublishLocalRelationChange(c *gc.C) {
-	var callCount int
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteRelations")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "PublishLocalRelationChange")
-		c.Check(arg, gc.DeepEquals, params.RemoteRelationsChanges{
-			Changes: []params.RemoteRelationChangeEvent{{
-				DepartedUnits: []int{1}}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	err := client.PublishLocalRelationChange(params.RemoteRelationChangeEvent{DepartedUnits: []int{1}})
-	c.Check(err, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
 func (s *remoteRelationsSuite) TestExportEntities(c *gc.C) {
 	var callCount int
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -284,47 +258,6 @@ func (s *remoteRelationsSuite) TestRemoteApplicationsResultsCount(c *gc.C) {
 	})
 	client := remoterelations.NewClient(apiCaller)
 	_, err := client.RemoteApplications([]string{"foo"})
-	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
-}
-
-func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
-	var callCount int
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "RemoteRelations")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "RegisterRemoteRelations")
-		c.Check(arg, gc.DeepEquals, params.RegisterRemoteRelations{
-			Relations: []params.RegisterRemoteRelation{{OfferName: "offeredapp"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.RemoteEntityIdResults{})
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		callCount++
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	result, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{OfferName: "offeredapp"})
-	c.Check(err, jc.ErrorIsNil)
-	c.Assert(result, gc.HasLen, 1)
-	c.Check(result[0].Error, gc.ErrorMatches, "FAIL")
-	c.Check(callCount, gc.Equals, 1)
-}
-
-func (s *remoteRelationsSuite) TestRegisterRemoteRelationCount(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.RemoteEntityIdResults)) = params.RemoteEntityIdResults{
-			Results: []params.RemoteEntityIdResult{
-				{Error: &params.Error{Message: "FAIL"}},
-				{Error: &params.Error{Message: "FAIL"}},
-			},
-		}
-		return nil
-	})
-	client := remoterelations.NewClient(apiCaller)
-	_, err := client.RegisterRemoteRelations(params.RegisterRemoteRelation{})
 	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
 }
 

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/apiserver/cloud"  // ModelUser Read
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/controller" // ModelUser Admin (although some methods check for read only)
+	"github.com/juju/juju/apiserver/crossmodelrelations"
 	"github.com/juju/juju/apiserver/deployer"
 	"github.com/juju/juju/apiserver/diskmanager"
 	"github.com/juju/juju/apiserver/facade"
@@ -214,6 +215,7 @@ func AllFacades() *facade.Registry {
 		reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 		reg("RemoteFirewaller", 1, remotefirewaller.NewStateRemoteFirewallerAPI)
 		reg("RemoteRelations", 1, remoterelations.NewStateRemoteRelationsAPI)
+		reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPI)
 	}
 
 	regRaw("AllWatcher", 1, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
 	coretesting "github.com/juju/juju/testing"
+	"gopkg.in/macaroon.v1"
 )
 
 type mockEnviron struct {

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/state"
 	statestorage "github.com/juju/juju/state/storage"
 	coretesting "github.com/juju/juju/testing"
-	"gopkg.in/macaroon.v1"
 )
 
 type mockEnviron struct {

--- a/apiserver/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/crossmodelrelations/crossmodelrelations.go
@@ -1,0 +1,307 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+)
+
+var logger = loggo.GetLogger("juju.apiserver.crossmodelrelations")
+
+// CrossModelRelationsAPI provides access to the CrossModelRelations API facade.
+type CrossModelRelationsAPI struct {
+	st         CrossModelRelationsState
+	resources  facade.Resources
+	authorizer facade.Authorizer
+}
+
+// NewStateCrossModelRelationsAPI creates a new server-side CrossModelRelations API facade
+// backed by global state.
+func NewStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI, error) {
+	return NewCrossModelRelationsAPI(stateShim{ctx.State()}, ctx.Resources(), ctx.Auth())
+}
+
+// NewCrossModelRelationsAPI returns a new server-side CrossModelRelationsAPI facade.
+func NewCrossModelRelationsAPI(
+	st CrossModelRelationsState,
+	resources facade.Resources,
+	authorizer facade.Authorizer,
+) (*CrossModelRelationsAPI, error) {
+	if !authorizer.AuthController() {
+		return nil, common.ErrPerm
+	}
+	return &CrossModelRelationsAPI{
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
+	}, nil
+}
+
+// PublishLocalRelationChange publishes local relations changes to the
+// remote side offering those relations.
+func (api *CrossModelRelationsAPI) PublishLocalRelationChange(
+	changes params.RemoteRelationsChanges,
+) (params.ErrorResults, error) {
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(changes.Changes)),
+	}
+	for i, change := range changes.Changes {
+		if err := api.publishRelationChange(change); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		}
+	}
+	return results, nil
+}
+
+func (api *CrossModelRelationsAPI) publishRelationChange(change params.RemoteRelationChangeEvent) error {
+	logger.Debugf("publish into model %v change: %+v", api.st.ModelUUID(), change)
+
+	relationTag, err := api.getRemoteEntityTag(change.RelationId)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, api.st.ModelUUID())
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
+
+	// Ensure the relation exists.
+	rel, err := api.st.KeyRelation(relationTag.Id())
+	if errors.IsNotFound(err) {
+		if change.Life != params.Alive {
+			return nil
+		}
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Look up the application on the remote side of this relation
+	// ie from the model which published this change.
+	applicationTag, err := api.getRemoteEntityTag(change.ApplicationId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
+
+	// If the remote model has destroyed the relation, do it here also.
+	if change.Life != params.Alive {
+		logger.Debugf("remote side of %v died", relationTag)
+		if err := rel.Destroy(); err != nil {
+			return errors.Trace(err)
+		}
+		// See if we need to remove the remote application proxy - we do this
+		// on the offering side as there is 1:1 between proxy and consuming app.
+		if applicationTag != nil {
+			remoteApp, err := api.st.RemoteApplication(applicationTag.Id())
+			if err != nil && !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+			if err == nil && remoteApp.IsConsumerProxy() {
+				logger.Debugf("destroy consuming app proxy for %v", applicationTag.Id())
+				if err := remoteApp.Destroy(); err != nil {
+					return errors.Trace(err)
+				}
+			}
+		}
+	}
+
+	// TODO(wallyworld) - deal with remote application being removed
+	if applicationTag == nil {
+		logger.Infof("no remote application found for %v", relationTag.Id())
+		return nil
+	}
+	logger.Debugf("remote applocation for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
+
+	for _, id := range change.DepartedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
+		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), relationTag.Id())
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		logger.Debugf("%s leaving scope", unitTag.Id())
+		if err := ru.LeaveScope(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	for _, change := range change.ChangedUnits {
+		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
+		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
+		ru, err := rel.RemoteUnit(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		inScope, err := ru.InScope()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		settings := make(map[string]interface{})
+		for k, v := range change.Settings {
+			settings[k] = v
+		}
+		if !inScope {
+			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
+			err = ru.EnterScope(settings)
+		} else {
+			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
+			err = ru.ReplaceSettings(settings)
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (api *CrossModelRelationsAPI) getRemoteEntityTag(id params.RemoteEntityId) (names.Tag, error) {
+	modelTag := names.NewModelTag(id.ModelUUID)
+	return api.st.GetRemoteEntity(modelTag, id.Token)
+}
+
+// RegisterRemoteRelations sets up the local model to participate
+// in the specified relations. This operation is idempotent.
+func (api *CrossModelRelationsAPI) RegisterRemoteRelations(
+	relations params.RegisterRemoteRelations,
+) (params.RemoteEntityIdResults, error) {
+	results := params.RemoteEntityIdResults{
+		Results: make([]params.RemoteEntityIdResult, len(relations.Relations)),
+	}
+	for i, relation := range relations.Relations {
+		// TODO(wallyworld) - check macaroon
+		if id, err := api.registerRemoteRelation(relation); err != nil {
+			results.Results[i].Error = common.ServerError(err)
+			continue
+		} else {
+			results.Results[i].Result = id
+		}
+	}
+	return results, nil
+}
+
+func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.RegisterRemoteRelation) (*params.RemoteEntityId, error) {
+	logger.Debugf("register remote relation %+v", relation)
+	// TODO(wallyworld) - do this as a transaction so the result is atomic
+	// Perform some initial validation - is the local application alive?
+
+	// Look up the offer record so get the local application to which we need to relate.
+	appOffers, err := api.st.ListOffers(crossmodel.ApplicationOfferFilter{
+		OfferName: relation.OfferName,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(appOffers) == 0 {
+		return nil, errors.NotFoundf("application offer %v", relation.OfferName)
+	}
+	localApplicationName := appOffers[0].ApplicationName
+
+	localApp, err := api.st.Application(localApplicationName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get application for offer %q", relation.OfferName)
+	}
+	if localApp.Life() != state.Alive {
+		// We don't want to leak the application name so just log it.
+		logger.Warningf("local application for offer %v not found", localApplicationName)
+		return nil, errors.NotFoundf("local application for offer %v", relation.OfferName)
+	}
+	eps, err := localApp.Endpoints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Does the requested local endpoint exist?
+	var localEndpoint *state.Endpoint
+	for _, ep := range eps {
+		if ep.Name == relation.LocalEndpointName {
+			localEndpoint = &ep
+			break
+		}
+	}
+	if localEndpoint == nil {
+		return nil, errors.NotFoundf("relation endpoint %v", relation.LocalEndpointName)
+	}
+
+	// Add the remote application reference. We construct a unique, opaque application name based on the
+	// token passed in from the consuming model. This model, which is offering the application being
+	// related to, does not need to know the name of the consuming application.
+	uniqueRemoteApplicationName := "remote-" + strings.Replace(relation.ApplicationId.Token, "-", "", -1)
+	remoteEndpoint := state.Endpoint{
+		ApplicationName: uniqueRemoteApplicationName,
+		Relation: charm.Relation{
+			Name:      relation.RemoteEndpoint.Name,
+			Scope:     relation.RemoteEndpoint.Scope,
+			Interface: relation.RemoteEndpoint.Interface,
+			Role:      relation.RemoteEndpoint.Role,
+			Limit:     relation.RemoteEndpoint.Limit,
+		},
+	}
+
+	remoteModelTag := names.NewModelTag(relation.ApplicationId.ModelUUID)
+	_, err = api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:            uniqueRemoteApplicationName,
+		OfferName:       relation.OfferName,
+		SourceModel:     names.NewModelTag(relation.ApplicationId.ModelUUID),
+		Token:           relation.ApplicationId.Token,
+		Endpoints:       []charm.Relation{remoteEndpoint.Relation},
+		IsConsumerProxy: true,
+	})
+	// If it already exists, that's fine.
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "adding remote application %v", uniqueRemoteApplicationName)
+	}
+	logger.Debugf("added remote application %v to local model with token %v", uniqueRemoteApplicationName, relation.ApplicationId.Token)
+
+	// Now add the relation if it doesn't already exist.
+	localRel, err := api.st.EndpointsRelation(*localEndpoint, remoteEndpoint)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	if err != nil {
+		localRel, err = api.st.AddRelation(*localEndpoint, remoteEndpoint)
+		// Again, if it already exists, that's fine.
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return nil, errors.Annotate(err, "adding remote relation")
+		}
+		logger.Debugf("added relation %v to model %v", localRel.Tag().Id(), api.st.ModelUUID())
+	}
+
+	// Ensure we have references recorded.
+	logger.Debugf("importing remote relation into model %v", api.st.ModelUUID())
+	logger.Debugf("remote model is %v", remoteModelTag.Id())
+
+	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
+	}
+	logger.Debugf("relation token %v exported for %v ", relation.RelationId.Token, localRel.Tag().Id())
+
+	// Export the local application from this model so we can tell the caller what the remote id is.
+	// NB we need to export the application last so that everything else is in place when the worker is
+	// woken up by the watcher.
+	token, err := api.st.ExportLocalEntity(names.NewApplicationTag(localApplicationName))
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, errors.Annotatef(err, "exporting local application %v", localApplicationName)
+	}
+	logger.Debugf("local application %v from model %v exported with token %v ", localApplicationName, api.st.ModelUUID(), token)
+	return &params.RemoteEntityId{
+		ModelUUID: api.st.ModelUUID(),
+		Token:     token,
+	}, nil
+}

--- a/apiserver/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/crossmodelrelations/crossmodelrelations_test.go
@@ -1,0 +1,139 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/crossmodelrelations"
+	"github.com/juju/juju/apiserver/params"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&remoteRelationsSuite{})
+
+type remoteRelationsSuite struct {
+	coretesting.BaseSuite
+
+	resources  *common.Resources
+	authorizer *apiservertesting.FakeAuthorizer
+	st         *mockState
+	api        *crossmodelrelations.CrossModelRelationsAPI
+}
+
+func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
+	s.BaseSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	}
+
+	s.st = newMockState()
+	api, err := crossmodelrelations.NewCrossModelRelationsAPI(s.st, s.resources, s.authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+	s.api = api
+}
+
+func (s *remoteRelationsSuite) TestPublishLocalRelationsChange(c *gc.C) {
+	s.st.remoteApplications["db2"] = &mockRemoteApplication{}
+	s.st.remoteEntities[names.NewApplicationTag("db2")] = "token-db2"
+	rel := newMockRelation(1)
+	ru1 := newMockRelationUnit()
+	ru2 := newMockRelationUnit()
+	rel.units["db2/1"] = ru1
+	rel.units["db2/2"] = ru2
+	s.st.relations["db2:db django:db"] = rel
+	s.st.remoteEntities[names.NewRelationTag("db2:db django:db")] = "token-db2:db django:db"
+	results, err := s.api.PublishLocalRelationChange(params.RemoteRelationsChanges{
+		Changes: []params.RemoteRelationChangeEvent{
+			{
+				Life: params.Alive,
+				ApplicationId: params.RemoteEntityId{
+					ModelUUID: "uuid",
+					Token:     "token-db2"},
+				RelationId: params.RemoteEntityId{
+					ModelUUID: "uuid",
+					Token:     "token-db2:db django:db"},
+				ChangedUnits: []params.RemoteRelationUnitChange{{
+					UnitId:   1,
+					Settings: map[string]interface{}{"foo": "bar"},
+				}},
+				DepartedUnits: []int{2},
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = results.Combine()
+	c.Assert(err, jc.ErrorIsNil)
+	s.st.CheckCalls(c, []testing.StubCall{
+		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2:db django:db"}},
+		{"KeyRelation", []interface{}{"db2:db django:db"}},
+		{"GetRemoteEntity", []interface{}{names.NewModelTag("uuid"), "token-db2"}},
+	})
+	ru1.CheckCalls(c, []testing.StubCall{
+		{"InScope", []interface{}{}},
+		{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
+	})
+	ru2.CheckCalls(c, []testing.StubCall{
+		{"LeaveScope", []interface{}{}},
+	})
+}
+
+func (s *remoteRelationsSuite) assertRegisterRemoteRelations(c *gc.C) {
+	app := &mockApplication{}
+	app.eps = []state.Endpoint{{
+		ApplicationName: "offeredapp",
+		Relation:        charm.Relation{Name: "local"},
+	}}
+	s.st.applications["offeredapp"] = app
+	s.st.offers = []crossmodel.ApplicationOffer{{
+		OfferName:       "offered",
+		ApplicationName: "offeredapp",
+	}}
+	results, err := s.api.RegisterRemoteRelations(params.RegisterRemoteRelations{
+		Relations: []params.RegisterRemoteRelation{{
+			ApplicationId:     params.RemoteEntityId{ModelUUID: "model-uuid", Token: "app-token"},
+			RelationId:        params.RemoteEntityId{ModelUUID: "model-uuid", Token: "rel-token"},
+			RemoteEndpoint:    params.RemoteEndpoint{Name: "remote"},
+			OfferName:         "offered",
+			LocalEndpointName: "local",
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	result := results.Results[0]
+	c.Assert(result.Error, gc.IsNil)
+	c.Check(result.Result, jc.DeepEquals, &params.RemoteEntityId{
+		ModelUUID: coretesting.ModelTag.Id(), Token: "token-offeredapp"})
+	expectedRemoteApp := s.st.remoteApplications["remote-apptoken"]
+	expectedRemoteApp.Stub = testing.Stub{} // don't care about api calls
+
+	c.Check(expectedRemoteApp, jc.DeepEquals, &mockRemoteApplication{consumerproxy: true})
+	expectedRel := s.st.relations["offeredapp:local remote-apptoken:remote"]
+	expectedRel.Stub = testing.Stub{} // don't care about api calls
+	c.Check(expectedRel, jc.DeepEquals, &mockRelation{key: "offeredapp:local remote-apptoken:remote"})
+	c.Check(s.st.remoteEntities, gc.HasLen, 2)
+	c.Check(s.st.remoteEntities[names.NewApplicationTag("offeredapp")], gc.Equals, "token-offeredapp")
+	c.Check(s.st.remoteEntities[names.NewRelationTag("offeredapp:local remote-apptoken:remote")], gc.Equals, "rel-token")
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelations(c *gc.C) {
+	s.assertRegisterRemoteRelations(c)
+}
+
+func (s *remoteRelationsSuite) TestRegisterRemoteRelationsIdempotent(c *gc.C) {
+	s.assertRegisterRemoteRelations(c)
+	s.assertRegisterRemoteRelations(c)
+}

--- a/apiserver/crossmodelrelations/mock_test.go
+++ b/apiserver/crossmodelrelations/mock_test.go
@@ -1,0 +1,285 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	"gopkg.in/juju/names.v2"
+
+	"github.com/juju/juju/apiserver/crossmodelrelations"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type mockState struct {
+	testing.Stub
+	relations          map[string]*mockRelation
+	remoteApplications map[string]*mockRemoteApplication
+	applications       map[string]*mockApplication
+	offers             []crossmodel.ApplicationOffer
+	remoteEntities     map[names.Tag]string
+}
+
+func newMockState() *mockState {
+	return &mockState{
+		relations:          make(map[string]*mockRelation),
+		remoteApplications: make(map[string]*mockRemoteApplication),
+		applications:       make(map[string]*mockApplication),
+		remoteEntities:     make(map[names.Tag]string),
+	}
+}
+
+func (st *mockState) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+	return st.offers, nil
+}
+
+func (st *mockState) ModelUUID() string {
+	return coretesting.ModelTag.Id()
+}
+
+func (st *mockState) AddRelation(eps ...state.Endpoint) (crossmodelrelations.Relation, error) {
+	rel := &mockRelation{
+		key: fmt.Sprintf("%v:%v %v:%v", eps[0].ApplicationName, eps[0].Name, eps[1].ApplicationName, eps[1].Name)}
+	st.relations[rel.key] = rel
+	return rel, nil
+}
+
+func (st *mockState) EndpointsRelation(eps ...state.Endpoint) (crossmodelrelations.Relation, error) {
+	rel := &mockRelation{
+		key: fmt.Sprintf("%v:%v %v:%v", eps[0].ApplicationName, eps[0].Name, eps[1].ApplicationName, eps[1].Name)}
+	st.relations[rel.key] = rel
+	return rel, nil
+}
+
+func (st *mockState) AddRemoteApplication(params state.AddRemoteApplicationParams) (crossmodelrelations.RemoteApplication, error) {
+	app := &mockRemoteApplication{consumerproxy: params.IsConsumerProxy}
+	st.remoteApplications[params.Name] = app
+	return app, nil
+}
+
+func (st *mockState) ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error {
+	st.MethodCall(st, "ImportRemoteEntity", sourceModel, entity, token)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	if _, ok := st.remoteEntities[entity]; ok {
+		return errors.AlreadyExistsf(entity.Id())
+	}
+	st.remoteEntities[entity] = token
+	return nil
+}
+
+func (st *mockState) RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error {
+	st.MethodCall(st, "RemoveRemoteEntity", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return err
+	}
+	delete(st.remoteEntities, entity)
+	return nil
+}
+
+func (st *mockState) ExportLocalEntity(entity names.Tag) (string, error) {
+	st.MethodCall(st, "ExportLocalEntity", entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	if token, ok := st.remoteEntities[entity]; ok {
+		return token, errors.AlreadyExistsf(entity.Id())
+	}
+	token := "token-" + entity.Id()
+	st.remoteEntities[entity] = token
+	return token, nil
+}
+
+func (st *mockState) GetRemoteEntity(sourceModel names.ModelTag, token string) (names.Tag, error) {
+	st.MethodCall(st, "GetRemoteEntity", sourceModel, token)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	for e, t := range st.remoteEntities {
+		if t == token {
+			return e, nil
+		}
+	}
+	return nil, errors.NotFoundf("token %v", token)
+}
+
+func (st *mockState) GetToken(sourceModel names.ModelTag, entity names.Tag) (string, error) {
+	st.MethodCall(st, "GetToken", sourceModel, entity)
+	if err := st.NextErr(); err != nil {
+		return "", err
+	}
+	return "token-" + entity.String(), nil
+}
+
+func (st *mockState) KeyRelation(key string) (crossmodelrelations.Relation, error) {
+	st.MethodCall(st, "KeyRelation", key)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	r, ok := st.relations[key]
+	if !ok {
+		return nil, errors.NotFoundf("relation %q", key)
+	}
+	return r, nil
+}
+
+func (st *mockState) Relation(id int) (crossmodelrelations.Relation, error) {
+	st.MethodCall(st, "Relation", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	for _, r := range st.relations {
+		if r.id == id {
+			return r, nil
+		}
+	}
+	return nil, errors.NotFoundf("relation %d", id)
+}
+
+func (st *mockState) RemoteApplication(id string) (crossmodelrelations.RemoteApplication, error) {
+	st.MethodCall(st, "RemoteApplication", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	a, ok := st.remoteApplications[id]
+	if !ok {
+		return nil, errors.NotFoundf("remote application %q", id)
+	}
+	return a, nil
+}
+
+func (st *mockState) Application(id string) (crossmodelrelations.Application, error) {
+	st.MethodCall(st, "Application", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	a, ok := st.applications[id]
+	if !ok {
+		return nil, errors.NotFoundf("application %q", id)
+	}
+	return a, nil
+}
+
+type mockRelation struct {
+	testing.Stub
+	id    int
+	key   string
+	units map[string]crossmodelrelations.RelationUnit
+}
+
+func newMockRelation(id int) *mockRelation {
+	return &mockRelation{
+		id:    id,
+		units: make(map[string]crossmodelrelations.RelationUnit),
+	}
+}
+
+func (r *mockRelation) Tag() names.Tag {
+	r.MethodCall(r, "Tag")
+	return names.NewRelationTag(r.key)
+}
+
+func (r *mockRelation) Destroy() error {
+	r.MethodCall(r, "Destroy")
+	return r.NextErr()
+}
+
+func (r *mockRelation) RemoteUnit(unitId string) (crossmodelrelations.RelationUnit, error) {
+	r.MethodCall(r, "RemoteUnit", unitId)
+	if err := r.NextErr(); err != nil {
+		return nil, err
+	}
+	u, ok := r.units[unitId]
+	if !ok {
+		return nil, errors.NotFoundf("unit %q", unitId)
+	}
+	return u, nil
+}
+
+type mockRemoteApplication struct {
+	testing.Stub
+	consumerproxy bool
+}
+
+func (r *mockRemoteApplication) IsConsumerProxy() bool {
+	r.MethodCall(r, "IsConsumerProxy")
+	return r.consumerproxy
+}
+
+func (r *mockRemoteApplication) Destroy() error {
+	r.MethodCall(r, "Destroy")
+	return r.NextErr()
+}
+
+type mockApplication struct {
+	testing.Stub
+	life state.Life
+	eps  []state.Endpoint
+}
+
+func (a *mockApplication) Endpoints() ([]state.Endpoint, error) {
+	a.MethodCall(a, "Endpoints")
+	return a.eps, nil
+}
+
+func (a *mockApplication) Life() state.Life {
+	a.MethodCall(a, "Life")
+	return a.life
+}
+
+type mockRelationUnit struct {
+	testing.Stub
+	inScope  bool
+	settings map[string]interface{}
+}
+
+func newMockRelationUnit() *mockRelationUnit {
+	return &mockRelationUnit{
+		settings: make(map[string]interface{}),
+	}
+}
+
+func (u *mockRelationUnit) InScope() (bool, error) {
+	u.MethodCall(u, "InScope")
+	return u.inScope, u.NextErr()
+}
+
+func (u *mockRelationUnit) LeaveScope() error {
+	u.MethodCall(u, "LeaveScope")
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.inScope = false
+	return nil
+}
+
+func (u *mockRelationUnit) EnterScope(settings map[string]interface{}) error {
+	u.MethodCall(u, "EnterScope", settings)
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.inScope = true
+	u.settings = make(map[string]interface{})
+	for k, v := range settings {
+		u.settings[k] = v
+	}
+	return nil
+}
+
+func (u *mockRelationUnit) ReplaceSettings(settings map[string]interface{}) error {
+	u.MethodCall(u, "ReplaceSettings", settings)
+	if err := u.NextErr(); err != nil {
+		return err
+	}
+	u.settings = make(map[string]interface{})
+	for k, v := range settings {
+		u.settings[k] = v
+	}
+	return nil
+}

--- a/apiserver/crossmodelrelations/package_test.go
+++ b/apiserver/crossmodelrelations/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelrelations_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/crossmodelrelations/state.go
+++ b/apiserver/crossmodelrelations/state.go
@@ -1,20 +1,19 @@
-// Copyright 2015 Canonical Ltd.
+// Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package remoterelations
+package crossmodelrelations
 
 import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
-	"gopkg.in/macaroon.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/status"
 )
 
 // RemoteRelationState provides the subset of global state required by the
 // remote relations facade.
-type RemoteRelationsState interface {
+type CrossModelRelationsState interface {
 	// ModelUUID returns the model UUID for the model
 	// controlled by this state instance.
 	ModelUUID() string
@@ -23,24 +22,21 @@ type RemoteRelationsState interface {
 	// be derived unambiguously from the relation's endpoints).
 	KeyRelation(string) (Relation, error)
 
+	// AddRelation adds a relation between the specified endpoints and returns the relation info.
+	AddRelation(...state.Endpoint) (Relation, error)
+
+	// EndpointsRelation returns the existing relation with the given endpoints.
+	EndpointsRelation(...state.Endpoint) (Relation, error)
+
+	// AddRemoteApplication creates a new remote application record, having the supplied relation endpoints,
+	// with the supplied name (which must be unique across all applications, local and remote).
+	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
+
 	// RemoteApplication returns a remote application by name.
 	RemoteApplication(string) (RemoteApplication, error)
 
 	// Application returns a local application by name.
 	Application(string) (Application, error)
-
-	// WatchRemoteApplications returns a StringsWatcher that notifies of changes to
-	// the lifecycles of the remote applications in the model.
-	WatchRemoteApplications() state.StringsWatcher
-
-	// WatchRemoteApplicationRelations returns a StringsWatcher that notifies of
-	// changes to the lifecycles of relations involving the specified remote
-	// application.
-	WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error)
-
-	// WatchRemoteRelations returns a StringsWatcher that notifies of changes to
-	// the lifecycles of remote relations in the model.
-	WatchRemoteRelations() state.StringsWatcher
 
 	// ExportLocalEntity adds an entity to the remote entities collection,
 	// returning an opaque token that uniquely identifies the entity within
@@ -55,86 +51,78 @@ type RemoteRelationsState interface {
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModel names.ModelTag, entity names.Tag, token string) error
 
-	// RemoveRemoteEntity removes the specified entity from the remote entities collection.
-	RemoveRemoteEntity(sourceModel names.ModelTag, entity names.Tag) error
-
-	// GetToken returns the token associated with the entity with the given tag
-	// and model.
-	GetToken(names.ModelTag, names.Tag) (string, error)
+	// ListOffers returns the application offers matching any one of the filter terms.
+	ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error)
 }
 
 // Relation provides access a relation in global state.
 type Relation interface {
-	// Id returns the integer internal relation key.
-	Id() int
+	// Destroy ensures that the relation will be removed at some point; if
+	// no units are currently in scope, it will be removed immediately.
+	Destroy() error
 
 	// Tag returns the relation's tag.
 	Tag() names.Tag
 
-	// Life returns the relation's current life state.
-	Life() state.Life
-
 	// Endpoints returns the endpoints that constitute the relation.
-	Endpoints() []state.Endpoint
-
-	// Unit returns a RelationUnit for the unit with the supplied ID.
-	Unit(unitId string) (RelationUnit, error)
-
-	// WatchUnits returns a watcher that notifies of changes to the units of the
-	// specified application in the relation.
-	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
+	// RemoteUnit returns a RelationUnit for the remote application unit
+	// with the supplied ID.
+	RemoteUnit(unitId string) (RelationUnit, error)
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,
 // and methods for modifying the unit's involvement in the relation.
 type RelationUnit interface {
-	// Settings returns the relation unit's settings within the relation.
-	Settings() (map[string]interface{}, error)
+	// EnterScope ensures that the unit has entered its scope in the
+	// relation. When the unit has already entered its scope, EnterScope
+	// will report success but make no changes to state.
+	EnterScope(settings map[string]interface{}) error
+
+	// InScope returns whether the relation unit has entered scope and
+	// not left it.
+	InScope() (bool, error)
+
+	// LeaveScope signals that the unit has left its scope in the relation.
+	// After the unit has left its relation scope, it is no longer a member
+	// of the relation; if the relation is dying when its last member unit
+	// leaves, it is removed immediately. It is not an error to leave a
+	// scope that the unit is not, or never was, a member of.
+	LeaveScope() error
+
+	// ReplaceSettings replaces the relation unit's settings within the
+	// relation.
+	ReplaceSettings(map[string]interface{}) error
 }
 
 // RemoteApplication represents the state of an application hosted in an external
 // (remote) model.
 type RemoteApplication interface {
-	// Name returns the name of the remote application.
-	Name() string
-
-	// OfferName returns the name the offering side has given to the remote application..
-	OfferName() string
-
-	// Tag returns the remote applications's tag.
-	Tag() names.Tag
-
-	// SourceModel returns the tag of the model hosting the remote application.
-	SourceModel() names.ModelTag
-
-	// Macaroon returns the macaroon used for authentication.
-	Macaroon() (*macaroon.Macaroon, error)
-
 	// IsConsumerProxy returns whether application is created
 	// from a registration operation by a consuming model.
 	IsConsumerProxy() bool
 
-	// URL returns the remote application URL, at which it is offered.
-	URL() (string, bool)
-
-	// Life returns the lifecycle state of the application.
-	Life() state.Life
-
-	// Status returns the status of the remote application.
-	Status() (status.StatusInfo, error)
+	// Destroy ensures that this remote application reference and all its relations
+	// will be removed at some point; if no relation involving the
+	// application has any units in scope, they are all removed immediately.
+	Destroy() error
 }
 
 // Application represents the state of a application hosted in the local model.
 type Application interface {
-	// Name is the name of the application.
-	Name() string
-
 	// Life returns the lifecycle state of the application.
 	Life() state.Life
+
+	// Endpoints returns the application's currently available relation endpoints.
+	Endpoints() ([]state.Endpoint, error)
 }
 
 type stateShim struct {
 	*state.State
+}
+
+func (st stateShim) ListOffers(filter ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
+	oa := state.NewApplicationOffers(st.State)
+	return oa.ListOffers(filter...)
 }
 
 func (st stateShim) ExportLocalEntity(entity names.Tag) (string, error) {
@@ -170,6 +158,30 @@ func (st stateShim) KeyRelation(key string) (Relation, error) {
 	return relationShim{r, st.State}, nil
 }
 
+func (st stateShim) Relation(id int) (Relation, error) {
+	r, err := st.State.Relation(id)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) AddRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.AddRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
+func (st stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
+	r, err := st.State.EndpointsRelation(eps...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return relationShim{r, st.State}, nil
+}
+
 func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
 	a, err := st.State.RemoteApplication(name)
 	if err != nil {
@@ -178,12 +190,12 @@ func (st stateShim) RemoteApplication(name string) (RemoteApplication, error) {
 	return &remoteApplicationShim{a}, nil
 }
 
-func (st stateShim) WatchRemoteApplicationRelations(applicationName string) (state.StringsWatcher, error) {
-	a, err := st.State.RemoteApplication(applicationName)
+func (st stateShim) AddRemoteApplication(args state.AddRemoteApplicationParams) (RemoteApplication, error) {
+	a, err := st.State.AddRemoteApplication(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return a.WatchRelations(), nil
+	return remoteApplicationShim{a}, nil
 }
 
 type relationShim struct {
@@ -199,28 +211,24 @@ func (r relationShim) RemoteUnit(unitId string) (RelationUnit, error) {
 	return relationUnitShim{ru}, nil
 }
 
-func (r relationShim) Unit(unitId string) (RelationUnit, error) {
-	unit, err := r.st.Unit(unitId)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ru, err := r.Relation.Unit(unit)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return relationUnitShim{ru}, nil
-}
-
 type relationUnitShim struct {
 	*state.RelationUnit
 }
 
-func (r relationUnitShim) Settings() (map[string]interface{}, error) {
+func (r relationUnitShim) ReplaceSettings(s map[string]interface{}) error {
 	settings, err := r.RelationUnit.Settings()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	return settings.Map(), nil
+	settings.Update(s)
+	for _, key := range settings.Keys() {
+		if _, ok := s[key]; ok {
+			continue
+		}
+		settings.Delete(key)
+	}
+	_, err = settings.Write()
+	return errors.Trace(err)
 }
 
 type remoteApplicationShim struct {

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -4,42 +4,32 @@
 package remoterelations
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.remoterelations")
-
-// RemoteRelationsAPI provides access to the Provisioner API facade.
+// RemoteRelationsAPI provides access to the RemoteRelations API facade.
 type RemoteRelationsAPI struct {
 	st         RemoteRelationsState
-	pool       StatePool
 	resources  facade.Resources
 	authorizer facade.Authorizer
 }
 
-// NewRemoteRelationsAPI creates a new server-side RemoteRelationsAPI facade
+// NewStateRemoteRelationsAPI creates a new server-side RemoteRelationsAPI facade
 // backed by global state.
 func NewStateRemoteRelationsAPI(ctx facade.Context) (*RemoteRelationsAPI, error) {
-	return NewRemoteRelationsAPI(stateShim{ctx.State()}, statePoolShim{ctx.StatePool()}, ctx.Resources(), ctx.Auth())
+	return NewRemoteRelationsAPI(stateShim{ctx.State()}, ctx.Resources(), ctx.Auth())
 }
 
 // NewRemoteRelationsAPI returns a new server-side RemoteRelationsAPI facade.
 func NewRemoteRelationsAPI(
 	st RemoteRelationsState,
-	pool StatePool,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*RemoteRelationsAPI, error) {
@@ -48,7 +38,6 @@ func NewRemoteRelationsAPI(
 	}
 	return &RemoteRelationsAPI{
 		st:         st,
-		pool:       pool,
 		resources:  resources,
 		authorizer: authorizer,
 	}, nil
@@ -304,262 +293,6 @@ func (api *RemoteRelationsAPI) RemoteApplications(entities params.Entities) (par
 		results.Results[i].Result = remoteApplication
 	}
 	return results, nil
-}
-
-// PublishLocalRelationChange publishes local relations changes to the
-// remote side offering those relations.
-func (api *RemoteRelationsAPI) PublishLocalRelationChange(
-	changes params.RemoteRelationsChanges,
-) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(changes.Changes)),
-	}
-	for i, change := range changes.Changes {
-		if err := api.publishRelationChange(change); err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		}
-	}
-	return results, nil
-}
-
-func (api *RemoteRelationsAPI) publishRelationChange(change params.RemoteRelationChangeEvent) error {
-	logger.Debugf("publish into model %v change: %+v", api.st.ModelUUID(), change)
-
-	relationTag, err := api.getRemoteEntityTag(change.RelationId)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debugf("not found relation tag %+v in model %v, exit early", change.RelationId, api.st.ModelUUID())
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	logger.Debugf("relation tag for remote id %+v is %v", change.RelationId, relationTag)
-
-	// Ensure the relation exists.
-	rel, err := api.st.KeyRelation(relationTag.Id())
-	if errors.IsNotFound(err) {
-		if change.Life != params.Alive {
-			return nil
-		}
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Look up the application on the remote side of this relation
-	// ie from the model which published this change.
-	applicationTag, err := api.getRemoteEntityTag(change.ApplicationId)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	logger.Debugf("application tag for remote id %+v is %v", change.ApplicationId, applicationTag)
-
-	// If the remote model has destroyed the relation, do it here also.
-	if change.Life != params.Alive {
-		logger.Debugf("remote side of %v died", relationTag)
-		if err := rel.Destroy(); err != nil {
-			return errors.Trace(err)
-		}
-		// See if we need to remove the remote application proxy - we do this
-		// on the offering side as there is 1:1 between proxy and consuming app.
-		if applicationTag != nil {
-			remoteApp, err := api.st.RemoteApplication(applicationTag.Id())
-			if err != nil && !errors.IsNotFound(err) {
-				return errors.Trace(err)
-			}
-			if err == nil && remoteApp.IsConsumerProxy() {
-				logger.Debugf("destroy consuming app proxy for %v", remoteApp.Name())
-				if err := remoteApp.Destroy(); err != nil {
-					return errors.Trace(err)
-				}
-			}
-		}
-	}
-
-	// TODO(wallyworld) - deal with remote application being removed
-	if applicationTag == nil {
-		logger.Infof("no remote application found for %v", relationTag.Id())
-		return nil
-	}
-	logger.Debugf("remote applocation for changed relation %v is %v", relationTag.Id(), applicationTag.Id())
-
-	for _, id := range change.DepartedUnits {
-		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
-		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), relationTag.Id())
-		ru, err := rel.RemoteUnit(unitTag.Id())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		logger.Debugf("%s leaving scope", unitTag.Id())
-		if err := ru.LeaveScope(); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	for _, change := range change.ChangedUnits {
-		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), change.UnitId))
-		logger.Debugf("changed unit tag for remote id %v is %v", change.UnitId, unitTag)
-		ru, err := rel.RemoteUnit(unitTag.Id())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		inScope, err := ru.InScope()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		settings := make(map[string]interface{})
-		for k, v := range change.Settings {
-			settings[k] = v
-		}
-		if !inScope {
-			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
-			err = ru.EnterScope(settings)
-		} else {
-			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
-			err = ru.ReplaceSettings(settings)
-		}
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-func (api *RemoteRelationsAPI) getRemoteEntityTag(id params.RemoteEntityId) (names.Tag, error) {
-	modelTag := names.NewModelTag(id.ModelUUID)
-	return api.st.GetRemoteEntity(modelTag, id.Token)
-}
-
-// RegisterRemoteRelations sets up the local model to participate
-// in the specified relations. This operation is idempotent.
-func (api *RemoteRelationsAPI) RegisterRemoteRelations(
-	relations params.RegisterRemoteRelations,
-) (params.RemoteEntityIdResults, error) {
-	results := params.RemoteEntityIdResults{
-		Results: make([]params.RemoteEntityIdResult, len(relations.Relations)),
-	}
-	for i, relation := range relations.Relations {
-		// TODO(wallyworld) - check macaroon
-		if id, err := api.registerRemoteRelation(relation); err != nil {
-			results.Results[i].Error = common.ServerError(err)
-			continue
-		} else {
-			results.Results[i].Result = id
-		}
-	}
-	return results, nil
-}
-
-func (api *RemoteRelationsAPI) registerRemoteRelation(relation params.RegisterRemoteRelation) (*params.RemoteEntityId, error) {
-	logger.Debugf("register remote relation %+v", relation)
-	// TODO(wallyworld) - do this as a transaction so the result is atomic
-	// Perform some initial validation - is the local application alive?
-
-	// Look up the offer record so get the local application to which we need to relate.
-	appOffers, err := api.st.ListOffers(crossmodel.ApplicationOfferFilter{
-		OfferName: relation.OfferName,
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(appOffers) == 0 {
-		return nil, errors.NotFoundf("application offer %v", relation.OfferName)
-	}
-	localApplicationName := appOffers[0].ApplicationName
-
-	localApp, err := api.st.Application(localApplicationName)
-	if err != nil {
-		return nil, errors.Annotatef(err, "cannot get application for offer %q", relation.OfferName)
-	}
-	if localApp.Life() != state.Alive {
-		// We don't want to leak the application name so just log it.
-		logger.Warningf("local application for offer %v not found", localApplicationName)
-		return nil, errors.NotFoundf("local application for offer %v", relation.OfferName)
-	}
-	eps, err := localApp.Endpoints()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Does the requested local endpoint exist?
-	var localEndpoint *state.Endpoint
-	for _, ep := range eps {
-		if ep.Name == relation.LocalEndpointName {
-			localEndpoint = &ep
-			break
-		}
-	}
-	if localEndpoint == nil {
-		return nil, errors.NotFoundf("relation endpoint %v", relation.LocalEndpointName)
-	}
-
-	// Add the remote application reference. We construct a unique, opaque application name based on the
-	// token passed in from the consuming model. This model, which is offering the application being
-	// related to, does not need to know the name of the consuming application.
-	uniqueRemoteApplicationName := "remote-" + strings.Replace(relation.ApplicationId.Token, "-", "", -1)
-	remoteEndpoint := state.Endpoint{
-		ApplicationName: uniqueRemoteApplicationName,
-		Relation: charm.Relation{
-			Name:      relation.RemoteEndpoint.Name,
-			Scope:     relation.RemoteEndpoint.Scope,
-			Interface: relation.RemoteEndpoint.Interface,
-			Role:      relation.RemoteEndpoint.Role,
-			Limit:     relation.RemoteEndpoint.Limit,
-		},
-	}
-
-	remoteModelTag := names.NewModelTag(relation.ApplicationId.ModelUUID)
-	_, err = api.st.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:            uniqueRemoteApplicationName,
-		OfferName:       relation.OfferName,
-		SourceModel:     names.NewModelTag(relation.ApplicationId.ModelUUID),
-		Token:           relation.ApplicationId.Token,
-		Endpoints:       []charm.Relation{remoteEndpoint.Relation},
-		IsConsumerProxy: true,
-	})
-	// If it already exists, that's fine.
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "adding remote application %v", uniqueRemoteApplicationName)
-	}
-	logger.Debugf("added remote application %v to local model with token %v", uniqueRemoteApplicationName, relation.ApplicationId.Token)
-
-	// Now add the relation if it doesn't already exist.
-	localRel, err := api.st.EndpointsRelation(*localEndpoint, remoteEndpoint)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, errors.Trace(err)
-	}
-	if err != nil {
-		localRel, err = api.st.AddRelation(*localEndpoint, remoteEndpoint)
-		// Again, if it already exists, that's fine.
-		if err != nil && !errors.IsAlreadyExists(err) {
-			return nil, errors.Annotate(err, "adding remote relation")
-		}
-		logger.Debugf("added relation %v to model %v", localRel.Tag().Id(), api.st.ModelUUID())
-	}
-
-	// Ensure we have references recorded.
-	logger.Debugf("importing remote relation into model %v", api.st.ModelUUID())
-	logger.Debugf("remote model is %v", remoteModelTag.Id())
-
-	err = api.st.ImportRemoteEntity(remoteModelTag, localRel.Tag(), relation.RelationId.Token)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "importing remote relation %v to local model", localRel.Tag().Id())
-	}
-	logger.Debugf("relation token %v exported for %v ", relation.RelationId.Token, localRel.Tag().Id())
-
-	// Export the local application from this model so we can tell the caller what the remote id is.
-	// NB we need to export the application last so that everything else is in place when the worker is
-	// woken up by the watcher.
-	token, err := api.st.ExportLocalEntity(names.NewApplicationTag(localApp.Name()))
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, errors.Annotatef(err, "exporting local application %v", localApp.Name())
-	}
-	logger.Debugf("local application %v from model %v exported with token %v ", localApp.Name(), api.st.ModelUUID(), token)
-	return &params.RemoteEntityId{
-		ModelUUID: api.st.ModelUUID(),
-		Token:     token,
-	}, nil
 }
 
 // WatchRemoteApplications starts a strings watcher that notifies of the addition,

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -42,8 +42,6 @@ type RemoteRelationChangePublisher interface {
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
 type RemoteRelationsFacade interface {
-	RemoteRelationChangePublisher
-
 	// ImportRemoteEntity adds an entity to the remote entities collection
 	// with the specified opaque token.
 	ImportRemoteEntity(sourceModelUUID string, entity names.Tag, token string) error

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -11,11 +11,17 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/remoterelations"
 )
 
 func NewRemoteRelationsFacade(apiCaller base.APICaller) (RemoteRelationsFacade, error) {
 	facade := remoterelations.NewClient(apiCaller)
+	return facade, nil
+}
+
+func NewCrossModelRelationsFacade(apiCaller base.APICaller) (RemoteRelationChangePublisher, error) {
+	facade := crossmodelrelations.NewClient(apiCaller)
 	return facade, nil
 }
 
@@ -31,8 +37,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 // can be used be construct instances which publish remote relation
 // changes for a given model.
 
-// For now we use a facade on the same controller, but in future this
-// may evolve into a REST caller.
+// For now we use a facade, but in future this may evolve into a REST caller.
 func relationChangePublisherForModelFunc(
 	apiConnForModelFunc func(string) (api.Connection, error),
 ) func(string) (RemoteRelationChangePublisherCloser, error) {
@@ -41,7 +46,7 @@ func relationChangePublisherForModelFunc(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		facade, err := NewRemoteRelationsFacade(conn)
+		facade, err := NewCrossModelRelationsFacade(conn)
 		if err != nil {
 			conn.Close()
 			return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

The PR is almost 100% cut and paste of code blocks from one package to another.

The interesting code is a few lines of change in the remote relations worker. The methods to publish remote relations changes are split off onto a new crossmodel relations facade. This facade will then be independently developed further in subsequent PRs. The next effect is the remote relations worker now has 2 distinct facades that it uses - one for the local model to read/write/watch remote application/relation related artefacts, the other for the external model to register the relation and publish changes.

## QA steps

run up a cross model scenario

