### PR TITLE
cross model relations span controllers

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -284,25 +284,6 @@ func loginWithContext(ctx context.Context, st *state, info *Info) error {
 	}
 }
 
-type NewConnectionForModelFunc func(*Info) (func(string) (Connection, error), error)
-
-// NewConnectionForModel returns a function which returns a model API
-// connection for a specified model UUID, based on the specified api info.
-// Currently, such a connection will always be to a single controller.
-func NewConnectionForModel(apiInfo *Info) (func(string) (Connection, error), error) {
-	return func(modelUUID string) (Connection, error) {
-		apiInfo.ModelTag = names.NewModelTag(modelUUID)
-		conn, err := Open(apiInfo, DialOpts{
-			Timeout:    time.Second,
-			RetryDelay: 200 * time.Millisecond,
-		})
-		if err != nil {
-			return nil, errors.Annotatef(err, "failed to open API to model %s", modelUUID)
-		}
-		return conn, nil
-	}, nil
-}
-
 // hostSwitchingTransport provides an http.RoundTripper
 // that chooses an actual RoundTripper to use
 // depending on the destination host.

--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -222,7 +222,7 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 		return params.ConsumeOfferDetails{}, errors.Trace(err)
 	}
 	if url.Source != "" {
-		return params.ConsumeOfferDetails{}, errors.NotSupportedf("query for non-local application offers")
+		return params.ConsumeOfferDetails{}, errors.NotSupportedf("query for application offers on another controller")
 	}
 
 	found := params.ConsumeOfferDetailsResults{}
@@ -242,7 +242,8 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 		return params.ConsumeOfferDetails{}, errors.Trace(theOne.Error)
 	}
 	return params.ConsumeOfferDetails{
-		Offer:    theOne.Offer,
-		Macaroon: theOne.Macaroon,
+		Offer:          theOne.Offer,
+		Macaroon:       theOne.Macaroon,
+		ControllerInfo: theOne.ControllerInfo,
 	}, nil
 }

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -541,6 +541,9 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 		ApplicationDescription: "description",
 		Endpoints:              []params.RemoteEndpoint{{Name: "endpoint"}},
 	}
+	controllerInfo := &params.ExternalControllerInfo{
+		Addrs: []string{"1.2.3.4"},
+	}
 	mac, err := macaroon.New(nil, "id", "loc")
 	c.Assert(err, jc.ErrorIsNil)
 	var called bool
@@ -558,8 +561,9 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 			if results, ok := result.(*params.ConsumeOfferDetailsResults); ok {
 				result := params.ConsumeOfferDetailsResult{
 					ConsumeOfferDetails: params.ConsumeOfferDetails{
-						Offer:    &offer,
-						Macaroon: mac,
+						Offer:          &offer,
+						Macaroon:       mac,
+						ControllerInfo: controllerInfo,
 					},
 				}
 				results.Results = []params.ConsumeOfferDetailsResult{result}
@@ -571,8 +575,9 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(details, jc.DeepEquals, params.ConsumeOfferDetails{
-		Offer:    &offer,
-		Macaroon: mac,
+		Offer:          &offer,
+		Macaroon:       mac,
+		ControllerInfo: controllerInfo,
 	})
 }
 

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/juju/names.v2"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
@@ -173,4 +174,27 @@ func (c *State) WatchIngressAddressesForRelation(relationTag names.RelationTag) 
 	}
 	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
+}
+
+// ControllerAPIInfoForModels returns the controller api connection details for the specified model.
+func (c *State) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
+	modelTag := names.NewModelTag(modelUUID)
+	args := params.Entities{[]params.Entity{{Tag: modelTag.String()}}}
+	var results params.ControllerAPIInfoResults
+	err := c.facade.FacadeCall("ControllerAPIInfoForModels", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &api.Info{
+		Addrs:    result.Addresses,
+		CACert:   result.CACert,
+		ModelTag: modelTag,
+	}, nil
 }

--- a/api/firewaller/firewaller.go
+++ b/api/firewaller/firewaller.go
@@ -132,7 +132,7 @@ func (st *State) Relation(tag names.RelationTag) (*Relation, error) {
 }
 
 // WatchEgressAddressesForRelation returns a watcher that notifies when addresses,
-// from which connections to the offering side of the relation will originate.
+// from which connections will originate to the offering side of the relation, change.
 // Each event contains the entire set of addresses which the offering side is required
 // to allow for access to the other side of the relation.
 func (c *State) WatchEgressAddressesForRelation(relationTag names.RelationTag) (watcher.StringsWatcher, error) {

--- a/apiserver/agent/agent.go
+++ b/apiserver/agent/agent.go
@@ -49,7 +49,7 @@ func NewAgentAPIV2(st *state.State, resources facade.Resources, auth facade.Auth
 		PasswordChanger:     common.NewPasswordChanger(st, getCanChange),
 		RebootFlagClearer:   common.NewRebootFlagClearer(st, getCanChange),
 		ModelWatcher:        common.NewModelWatcher(st, resources, auth),
-		ControllerConfigAPI: common.NewControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		st:                  st,
 		auth:                auth,

--- a/apiserver/application/application.go
+++ b/apiserver/application/application.go
@@ -968,7 +968,7 @@ func (api *API) consumeOne(arg params.ConsumeApplicationArg) error {
 				ControllerTag: controllerTag,
 				Addrs:         arg.ControllerInfo.Addrs,
 				CACert:        arg.ControllerInfo.CACert,
-			}); err != nil {
+			}, sourceModelTag.Id()); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/apiserver/application/application_unit_test.go
+++ b/apiserver/application/application_unit_test.go
@@ -423,7 +423,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 			{ApplicationName: "hosted-mysql", Relation: charm.Relation{Name: "database", Interface: "mysql", Role: "provider"}}},
 		mac: mac,
 	})
-	c.Assert(s.backend.controllers[controllerUUID], jc.DeepEquals, crossmodel.ControllerInfo{
+	c.Assert(s.backend.controllers[coretesting.ModelTag.Id()], jc.DeepEquals, crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(controllerUUID),
 		CACert:        coretesting.CACert,
 		Addrs:         []string{"192.168.1.1:1234"},

--- a/apiserver/application/backend.go
+++ b/apiserver/application/backend.go
@@ -34,7 +34,7 @@ type Backend interface {
 	Machine(string) (Machine, error)
 	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)
-	SaveController(crossmodel.ControllerInfo) (ExternalController, error)
+	SaveController(info crossmodel.ControllerInfo, modelUUID string) (ExternalController, error)
 	ControllerTag() names.ControllerTag
 }
 
@@ -125,9 +125,9 @@ type stateShim struct {
 
 type ExternalController state.ExternalController
 
-func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo) (ExternalController, error) {
+func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo, modelUUID string) (ExternalController, error) {
 	api := state.NewExternalControllers(s.State)
-	return api.Save(controllerInfo)
+	return api.Save(controllerInfo, modelUUID)
 }
 
 // NewStateBackend converts a state.State into a Backend.

--- a/apiserver/application/mock_test.go
+++ b/apiserver/application/mock_test.go
@@ -424,8 +424,8 @@ func (m *mockExternalController) ControllerInfo() crossmodel.ControllerInfo {
 	return m.info
 }
 
-func (m *mockBackend) SaveController(controllerInfo crossmodel.ControllerInfo) (application.ExternalController, error) {
-	m.controllers[controllerInfo.ControllerTag.Id()] = controllerInfo
+func (m *mockBackend) SaveController(controllerInfo crossmodel.ControllerInfo, modelUUID string) (application.ExternalController, error) {
+	m.controllers[modelUUID] = controllerInfo
 	return &mockExternalController{controllerInfo.ControllerTag.Id(), controllerInfo}, nil
 }
 

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"gopkg.in/juju/names.v2"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -12,6 +14,11 @@ import (
 // facades - eg Provisioner and ControllerConfig.
 type ControllerConfigAPI struct {
 	st state.ControllerAccessor
+}
+
+// NewStateControllerConfig returns a new NewControllerConfigAPI.
+func NewStateControllerConfig(st *state.State) *ControllerConfigAPI {
+	return NewControllerConfig(&controllerStateShim{st})
 }
 
 // NewControllerConfig returns a new NewControllerConfigAPI.
@@ -30,4 +37,35 @@ func (s *ControllerConfigAPI) ControllerConfig() (params.ControllerConfigResult,
 	}
 	result.Config = params.ControllerConfig(config)
 	return result, nil
+}
+
+// ControllerAPIInfoForModels returns the controller api connection details for the specified models.
+func (s *ControllerConfigAPI) ControllerAPIInfoForModels(args params.Entities) (params.ControllerAPIInfoResults, error) {
+	var result params.ControllerAPIInfoResults
+	result.Results = make([]params.ControllerAPIInfoResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		modelTag, err := names.ParseModelTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = ServerError(err)
+			continue
+		}
+		ec, err := s.st.ControllerInfo(modelTag.Id())
+		if err != nil {
+			result.Results[i].Error = ServerError(err)
+			continue
+		}
+		result.Results[i].Addresses = ec.ControllerInfo().Addrs
+		result.Results[i].CACert = ec.ControllerInfo().CACert
+	}
+	return result, nil
+}
+
+type controllerStateShim struct {
+	*state.State
+}
+
+// ControllerInfo returns the external controller details for the specified model.
+func (s *controllerStateShim) ControllerInfo(modelUUID string) (state.ExternalController, error) {
+	ec := state.NewExternalControllers(s.State)
+	return ec.ControllerForModel(modelUUID)
 }

--- a/apiserver/controller/controller.go
+++ b/apiserver/controller/controller.go
@@ -78,7 +78,7 @@ func NewControllerAPI(ctx facade.Context) (*ControllerAPI, error) {
 	st := ctx.State()
 	environConfigGetter := stateenvirons.EnvironConfigGetter{st}
 	return &ControllerAPI{
-		ControllerConfigAPI: common.NewControllerConfig(st),
+		ControllerConfigAPI: common.NewStateControllerConfig(st),
 		ModelStatusAPI:      common.NewModelStatusAPI(common.NewModelManagerBackend(st), authorizer, apiUser),
 		CloudSpecAPI:        cloudspec.NewCloudSpec(environConfigGetter.CloudSpec, common.AuthFuncForTag(st.ModelTag())),
 		state:               st,

--- a/apiserver/firewaller/firewaller.go
+++ b/apiserver/firewaller/firewaller.go
@@ -45,6 +45,7 @@ type FirewallerAPIV3 struct {
 // FirewallerAPIV4 provides access to the Firewaller v4 API facade.
 type FirewallerAPIV4 struct {
 	*FirewallerAPIV3
+	*common.ControllerConfigAPI
 }
 
 // NewStateFirewallerAPIv3 creates a new server-side FirewallerAPIV3 facade.
@@ -61,7 +62,10 @@ func NewStateFirewallerAPIV4(context facade.Context) (*FirewallerAPIV4, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FirewallerAPIV4{facadev3}, nil
+	return &FirewallerAPIV4{
+		ControllerConfigAPI: common.NewStateControllerConfig(context.State()),
+		FirewallerAPIV3:     facadev3,
+	}, nil
 }
 
 // NewFirewallerAPI creates a new server-side FirewallerAPIV3 facade.

--- a/apiserver/firewaller/ingressaddresswatcher_test.go
+++ b/apiserver/firewaller/ingressaddresswatcher_test.go
@@ -45,7 +45,7 @@ func (s *addressWatcherSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState(coretesting.ModelTag.Id())
-	api, err := firewaller.NewFirewallerAPI(s.st, s.resources, s.authorizer, &mockcloudSpecAPI{})
+	api, err := firewaller.NewFirewallerAPI(s.st, s.resources, s.authorizer, &mockCloudSpecAPI{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }

--- a/apiserver/firewaller/mock_test.go
+++ b/apiserver/firewaller/mock_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/firewaller"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
-type mockcloudSpecAPI struct {
+type mockCloudSpecAPI struct {
 	// TODO - implement when remaining firewaller tests become unit tests
 	cloudspec.CloudSpecAPI
 }
@@ -36,6 +38,7 @@ type mockState struct {
 	units          map[string]*mockUnit
 	machines       map[string]*mockMachine
 	relations      map[string]*mockRelation
+	controllerInfo map[string]*mockControllerInfo
 	subnetsWatcher *mockStringsWatcher
 }
 
@@ -47,7 +50,20 @@ func newMockState(modelUUID string) *mockState {
 		units:          make(map[string]*mockUnit),
 		machines:       make(map[string]*mockMachine),
 		remoteEntities: make(map[names.Tag]string),
+		controllerInfo: make(map[string]*mockControllerInfo),
 		subnetsWatcher: newMockStringsWatcher(),
+	}
+}
+
+func (st *mockState) ControllerConfig() (controller.Config, error) {
+	return nil, errors.NotImplementedf("ControllerConfig")
+}
+
+func (st *mockState) ControllerInfo(modelUUID string) (state.ExternalController, error) {
+	if info, ok := st.controllerInfo[modelUUID]; !ok {
+		return nil, errors.NotFoundf("controller info for %v", modelUUID)
+	} else {
+		return info, nil
 	}
 }
 
@@ -182,6 +198,19 @@ func (a *mockApplication) AllUnits() (results []firewaller.Unit, err error) {
 		results = append(results, unit)
 	}
 	return results, a.NextErr()
+}
+
+type mockControllerInfo struct {
+	uuid string
+	info crossmodel.ControllerInfo
+}
+
+func (c *mockControllerInfo) Id() string {
+	return c.uuid
+}
+
+func (c *mockControllerInfo) ControllerInfo() crossmodel.ControllerInfo {
+	return c.info
 }
 
 type mockRelation struct {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -250,6 +250,18 @@ type ControllerConfigResult struct {
 	Config ControllerConfig `json:"config"`
 }
 
+// ControllerAPIInfoResult holds controller api address details.
+type ControllerAPIInfoResult struct {
+	Addresses []string `json:"addresses"`
+	CACert    string   `json:"cacert"`
+	Error     *Error   `json:"error,omitempty"`
+}
+
+// ControllerAPIInfoResults holds controller api address details results.
+type ControllerAPIInfoResults struct {
+	Results []ControllerAPIInfoResult `json:"results"`
+}
+
 // RelationUnit holds a relation and a unit tag.
 type RelationUnit struct {
 	Relation string `json:"relation"`

--- a/apiserver/provisioner/provisioner.go
+++ b/apiserver/provisioner/provisioner.go
@@ -122,7 +122,7 @@ func NewProvisionerAPI(st *state.State, resources facade.Resources, authorizer f
 		APIAddresser:            common.NewAPIAddresser(st, resources),
 		ModelWatcher:            common.NewModelWatcher(st, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),
-		ControllerConfigAPI:     common.NewControllerConfig(st),
+		ControllerConfigAPI:     common.NewStateControllerConfig(st),
 		InstanceIdGetter:        common.NewInstanceIdGetter(st, getAuthFunc),
 		ToolsFinder:             common.NewToolsFinder(configGetter, st, urlGetter),
 		ToolsGetter:             common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner),

--- a/apiserver/remoterelations/remoterelations.go
+++ b/apiserver/remoterelations/remoterelations.go
@@ -16,6 +16,7 @@ import (
 
 // RemoteRelationsAPI provides access to the RemoteRelations API facade.
 type RemoteRelationsAPI struct {
+	*common.ControllerConfigAPI
 	st         RemoteRelationsState
 	resources  facade.Resources
 	authorizer facade.Authorizer
@@ -26,6 +27,7 @@ type RemoteRelationsAPI struct {
 func NewStateRemoteRelationsAPI(ctx facade.Context) (*RemoteRelationsAPI, error) {
 	return NewRemoteRelationsAPI(
 		stateShim{st: ctx.State(), Backend: commoncrossmodel.GetBackend(ctx.State())},
+		common.NewStateControllerConfig(ctx.State()),
 		ctx.Resources(), ctx.Auth(),
 	)
 
@@ -34,6 +36,7 @@ func NewStateRemoteRelationsAPI(ctx facade.Context) (*RemoteRelationsAPI, error)
 // NewRemoteRelationsAPI returns a new server-side RemoteRelationsAPI facade.
 func NewRemoteRelationsAPI(
 	st RemoteRelationsState,
+	controllerCfgAPI *common.ControllerConfigAPI,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*RemoteRelationsAPI, error) {
@@ -41,9 +44,10 @@ func NewRemoteRelationsAPI(
 		return nil, common.ErrPerm
 	}
 	return &RemoteRelationsAPI{
-		st:         st,
-		resources:  resources,
-		authorizer: authorizer,
+		st:                  st,
+		ControllerConfigAPI: controllerCfgAPI,
+		resources:           resources,
+		authorizer:          authorizer,
 	}, nil
 }
 

--- a/apiserver/remoterelations/remoterelations_test.go
+++ b/apiserver/remoterelations/remoterelations_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/remoterelations"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -42,7 +43,7 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	api, err := remoterelations.NewRemoteRelationsAPI(s.st, s.resources, s.authorizer)
+	api, err := remoterelations.NewRemoteRelationsAPI(s.st, common.NewControllerConfig(s.st), s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -386,4 +387,24 @@ func (s *remoteRelationsSuite) TestConsumeRemoteRelationChange(c *gc.C) {
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
 		{"GetRemoteEntity", []interface{}{names.NewModelTag(coretesting.ModelTag.Id()), "app-token"}},
 	})
+}
+
+func (s *remoteRelationsSuite) TestControllerAPIInfoForModels(c *gc.C) {
+	controllerInfo := &mockControllerInfo{
+		uuid: "some uuid",
+		info: crossmodel.ControllerInfo{
+			Addrs:  []string{"1.2.3.4/32"},
+			CACert: coretesting.CACert,
+		},
+	}
+	s.st.controllerInfo[coretesting.ModelTag.Id()] = controllerInfo
+	result, err := s.api.ControllerAPIInfoForModels(
+		params.Entities{Entities: []params.Entity{{
+			Tag: coretesting.ModelTag.String(),
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Addresses, jc.SameContents, []string{"1.2.3.4/32"})
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(result.Results[0].CACert, gc.Equals, coretesting.CACert)
 }

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -51,6 +51,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 		crossmodel.ConsumeApplicationArgs{
 			ApplicationOffer: params.ApplicationOffer{
 				OfferName: "hosted-mysql",
+				OfferURL:  "bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
@@ -65,6 +66,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 		crossmodel.ConsumeApplicationArgs{
 			ApplicationOffer: params.ApplicationOffer{
 				OfferName: "hosted-mysql",
+				OfferURL:  "bob/prod.hosted-mysql",
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
@@ -221,6 +223,7 @@ func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferD
 	return params.ConsumeOfferDetails{
 		Offer: &params.ApplicationOffer{
 			OfferName: "hosted-mysql",
+			OfferURL:  "bob/prod.hosted-mysql",
 		},
 		Macaroon: m.mac,
 	}, nil

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -28,6 +28,7 @@ The remote offer is identified by providing a path to the offer:
 Examples:
     $ juju consume othermodel.mysql
     $ juju consume owner/othermodel.mysql
+    $ juju consume anothercontroller:owner/othermodel.mysql
 
 See also:
     add-relation
@@ -86,16 +87,20 @@ func (c *consumeCommand) getTargetAPI() (applicationConsumeAPI, error) {
 	return application.NewClient(root), nil
 }
 
-func (c *consumeCommand) getSourceAPI() (applicationConsumeDetailsAPI, error) {
+func (c *consumeCommand) getSourceAPI(url *crossmodel.ApplicationURL) (applicationConsumeDetailsAPI, error) {
 	if c.sourceAPI != nil {
 		return c.sourceAPI, nil
 	}
 
-	controllerName, err := c.ControllerName()
-	if err != nil {
-		return nil, errors.Trace(err)
+	if url.Source == "" {
+		var err error
+		controllerName, err := c.ControllerName()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		url.Source = controllerName
 	}
-	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), controllerName, "")
+	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), url.Source, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -120,16 +125,24 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		url.User = accountDetails.User
 		c.remoteApplication = url.Path()
 	}
-	sourceClient, err := c.getSourceAPI()
+	sourceClient, err := c.getSourceAPI(url)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer sourceClient.Close()
 
-	consumeDetails, err := sourceClient.GetConsumeDetails(url.String())
+	consumeDetails, err := sourceClient.GetConsumeDetails(url.AsLocal().String())
 	if err != nil {
 		return errors.Trace(err)
 	}
+	// Parse the offer details URL and add the source controller so
+	// things like status can show the original source of the offer.
+	offerURL, err := crossmodel.ParseApplicationURL(consumeDetails.Offer.OfferURL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	offerURL.Source = url.Source
+	consumeDetails.Offer.OfferURL = offerURL.String()
 
 	targetClient, err := c.getTargetAPI()
 	if err != nil {

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -90,9 +90,9 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 		err error
 	)
 	if alias != "" {
-		ctx, err = s.runConsume(c, "booster.uke", alias)
+		ctx, err = s.runConsume(c, "ctrl:booster.uke", alias)
 	} else {
-		ctx, err = s.runConsume(c, "booster.uke")
+		ctx, err = s.runConsume(c, "ctrl:booster.uke")
 	}
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := macaroon.New(nil, "id", "loc")
@@ -100,7 +100,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 	s.mockAPI.CheckCalls(c, []testing.StubCall{
 		{"GetConsumeDetails", []interface{}{"bob/booster.uke"}},
 		{"Consume", []interface{}{crossmodel.ConsumeApplicationArgs{
-			ApplicationOffer: params.ApplicationOffer{OfferName: "an offer"},
+			ApplicationOffer: params.ApplicationOffer{OfferName: "an offer", OfferURL: "ctrl:bob/booster.uke"},
 			ApplicationAlias: alias,
 			Macaroon:         mac,
 			ControllerInfo: &crossmodel.ControllerInfo{
@@ -113,7 +113,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 		{"Close", nil},
 		{"Close", nil},
 	})
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added bob/booster.uke as mary-weep\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Added ctrl:bob/booster.uke as mary-weep\n")
 }
 
 func (s *ConsumeSuite) TestSuccessModelDotApplication(c *gc.C) {
@@ -147,7 +147,7 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		return params.ConsumeOfferDetails{}, err
 	}
 	return params.ConsumeOfferDetails{
-		Offer:    &params.ApplicationOffer{OfferName: "an offer"},
+		Offer:    &params.ApplicationOffer{OfferName: "an offer", OfferURL: "bob/booster.uke"},
 		Macaroon: mac,
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),

--- a/cmd/juju/crossmodel/export_test.go
+++ b/cmd/juju/crossmodel/export_test.go
@@ -37,7 +37,7 @@ func NewOfferCommandForTest(
 }
 
 func NewShowEndpointsCommandForTest(store jujuclient.ClientStore, api ShowAPI) cmd.Command {
-	aCmd := &showCommand{newAPIFunc: func() (ShowAPI, error) {
+	aCmd := &showCommand{newAPIFunc: func(controllerName string) (ShowAPI, error) {
 		return api, nil
 	}}
 	aCmd.SetClientStore(store)
@@ -53,7 +53,7 @@ func NewListEndpointsCommandForTest(store jujuclient.ClientStore, api ListAPI) c
 }
 
 func NewFindEndpointsCommandForTest(store jujuclient.ClientStore, api FindAPI) cmd.Command {
-	aCmd := &findCommand{newAPIFunc: func() (FindAPI, error) {
+	aCmd := &findCommand{newAPIFunc: func(controllerName string) (FindAPI, error) {
 		return api, nil
 	}}
 	aCmd.SetClientStore(store)

--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -39,6 +39,7 @@ type findCommand struct {
 	RemoteEndpointsCommandBase
 
 	url            string
+	source         string
 	modelOwnerName string
 	modelName      string
 	offerName      string
@@ -46,15 +47,15 @@ type findCommand struct {
 	endpoint       string
 
 	out        cmd.Output
-	newAPIFunc func() (FindAPI, error)
+	newAPIFunc func(string) (FindAPI, error)
 }
 
 // NewFindEndpointsCommand constructs command that
 // allows to find offered application endpoints.
 func NewFindEndpointsCommand() cmd.Command {
 	findCmd := &findCommand{}
-	findCmd.newAPIFunc = func() (FindAPI, error) {
-		return findCmd.NewRemoteEndpointsAPI()
+	findCmd.newAPIFunc = func(controllerName string) (FindAPI, error) {
+		return findCmd.NewRemoteEndpointsAPI(controllerName)
 	}
 	return modelcmd.WrapController(findCmd)
 }
@@ -101,7 +102,7 @@ func (c *findCommand) Run(ctx *cmd.Context) (err error) {
 	if err := c.validateOrSetURL(); err != nil {
 		return errors.Trace(err)
 	}
-	api, err := c.newAPIFunc()
+	api, err := c.newAPIFunc(c.source)
 	if err != nil {
 		return err
 	}
@@ -142,11 +143,17 @@ func (c *findCommand) validateOrSetURL() error {
 	}
 	if c.url == "" {
 		c.url = controllerName + ":"
+		c.source = controllerName
 		return nil
 	}
 	urlParts, err := crossmodel.ParseApplicationURLParts(c.url)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if urlParts.Source != "" {
+		c.source = urlParts.Source
+	} else {
+		c.source = controllerName
 	}
 	user := urlParts.User
 	if user == "" {
@@ -159,9 +166,6 @@ func (c *findCommand) validateOrSetURL() error {
 	c.modelOwnerName = user
 	c.modelName = urlParts.ModelName
 	c.offerName = urlParts.ApplicationName
-	if urlParts.Source != "" && urlParts.Source != controllerName {
-		return errors.NotSupportedf("finding endpoints from another controller %q", urlParts.Source)
-	}
 	return nil
 }
 

--- a/cmd/juju/crossmodel/remoteendpoints.go
+++ b/cmd/juju/crossmodel/remoteendpoints.go
@@ -16,8 +16,8 @@ type RemoteEndpointsCommandBase struct {
 
 // NewRemoteEndpointsAPI returns a remote endpoints api for the root api endpoint
 // that the command returns.
-func (c *RemoteEndpointsCommandBase) NewRemoteEndpointsAPI() (*applicationoffers.Client, error) {
-	root, err := c.NewAPIRoot()
+func (c *RemoteEndpointsCommandBase) NewRemoteEndpointsAPI(controllerName string) (*applicationoffers.Client, error) {
+	root, err := c.CommandBase.NewAPIRoot(c.ClientStore(), controllerName, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/crossmodel/show.go
+++ b/cmd/juju/crossmodel/show.go
@@ -26,6 +26,7 @@ options:
 
 Examples:
    $ juju show-endpoints fred/prod.db2
+   $ juju show-endpoints anothercontroller:fred/prod.db2
 
 See also:
    find-endpoints
@@ -36,15 +37,15 @@ type showCommand struct {
 
 	url        string
 	out        cmd.Output
-	newAPIFunc func() (ShowAPI, error)
+	newAPIFunc func(string) (ShowAPI, error)
 }
 
 // NewShowOfferedEndpointCommand constructs command that
 // allows to show details of offered application's endpoint.
 func NewShowOfferedEndpointCommand() cmd.Command {
 	showCmd := &showCommand{}
-	showCmd.newAPIFunc = func() (ShowAPI, error) {
-		return showCmd.NewRemoteEndpointsAPI()
+	showCmd.newAPIFunc = func(controllerName string) (ShowAPI, error) {
+		return showCmd.NewRemoteEndpointsAPI(controllerName)
 	}
 	return modelcmd.WrapController(showCmd)
 }
@@ -79,16 +80,25 @@ func (c *showCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *showCommand) Run(ctx *cmd.Context) (err error) {
-	if err := c.validateSource(); err != nil {
-		return errors.Trace(err)
+	url, err := crossmodel.ParseApplicationURL(c.url)
+	if err != nil {
+		return err
 	}
-	api, err := c.newAPIFunc()
+	controllerName := url.Source
+	if controllerName == "" {
+		controllerName, err = c.ControllerName()
+		if err != nil {
+			return err
+		}
+	}
+	api, err := c.newAPIFunc(controllerName)
 	if err != nil {
 		return err
 	}
 	defer api.Close()
 
-	found, err := api.ApplicationOffer(c.url)
+	url.Source = ""
+	found, err := api.ApplicationOffer(url.String())
 	if err != nil {
 		return err
 	}
@@ -98,24 +108,6 @@ func (c *showCommand) Run(ctx *cmd.Context) (err error) {
 		return err
 	}
 	return c.out.Write(ctx, output)
-}
-
-// validateSource checks that the offer is from the
-// current controller.
-func (c *showCommand) validateSource() error {
-	url, err := crossmodel.ParseApplicationURL(c.url)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	controllerName, err := c.ControllerName()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	// For now we only support offers on the current controller.
-	if url.Source != "" && url.Source != controllerName {
-		return errors.NotSupportedf("showing endpoints from another controller %q", url.Source)
-	}
-	return nil
 }
 
 // ShowAPI defines the API methods that cross model show command uses.

--- a/cmd/juju/crossmodel/show_test.go
+++ b/cmd/juju/crossmodel/show_test.go
@@ -38,10 +38,6 @@ func (s *showSuite) TestShowNoUrl(c *gc.C) {
 	s.assertShowError(c, nil, ".*must specify endpoint URL.*")
 }
 
-func (s *showSuite) TestShowDifferentController(c *gc.C) {
-	s.assertShowError(c, []string{"different:user/model.offer"}, `showing endpoints from another controller "different" not supported`)
-}
-
 func (s *showSuite) TestShowApiError(c *gc.C) {
 	s.mockAPI.msg = "fail"
 	s.assertShowError(c, []string{"fred/model.db2"}, ".*fail.*")
@@ -78,6 +74,20 @@ func (s *showSuite) TestShowTabular(c *gc.C) {
 URL             Access   Description                                 Endpoint  Interface  Role
 fred/model.db2  consume  IBM DB2 Express Server Edition is an entry  db2       http       requirer
                          level database system                       log       http       provider
+
+`[1:],
+	)
+}
+
+func (s *showSuite) TestShowDifferentController(c *gc.C) {
+	s.mockAPI.controllerName = "different"
+	s.assertShow(
+		c,
+		[]string{"different:fred/model.db2", "--format", "tabular"},
+		`
+URL                       Access   Description                                 Endpoint  Interface  Role
+different:fred/model.db2  consume  IBM DB2 Express Server Edition is an entry  db2       http       requirer
+                                   level database system                       log       http       provider
 
 `[1:],
 	)
@@ -131,7 +141,8 @@ func (s *showSuite) assertShowError(c *gc.C, args []string, expected string) {
 }
 
 type mockShowAPI struct {
-	msg, desc string
+	controllerName string
+	msg, desc      string
 }
 
 func (s mockShowAPI) Close() error {
@@ -143,9 +154,13 @@ func (s mockShowAPI) ApplicationOffer(url string) (params.ApplicationOffer, erro
 		return params.ApplicationOffer{}, errors.New(s.msg)
 	}
 
+	offerURL := "fred/model.db2"
+	if s.controllerName != "" {
+		offerURL = s.controllerName + ":" + offerURL
+	}
 	return params.ApplicationOffer{
 		OfferName:              "hosted-db2",
-		OfferURL:               "fred/model.db2",
+		OfferURL:               offerURL,
 		ApplicationDescription: s.desc,
 		Endpoints: []params.RemoteEndpoint{
 			{Name: "log", Interface: "http", Role: charm.RoleProvider},

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -132,6 +132,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 			url, err := crossmodel.ParseApplicationURL(app.ApplicationURL)
 			if err == nil {
 				store = url.Source
+				url.Source = ""
 				urlPath = url.Path()
 				if store == "" {
 					store = "local"

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -230,10 +230,10 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			Scope:         modelTag,
 		})),
 		firewallerName: ifNotMigrating(firewaller.Manifold(firewaller.ManifoldConfig{
-			AgentName:          agentName,
-			APICallerName:      apiCallerName,
-			EnvironName:        environTrackerName,
-			NewAPIConnForModel: api.NewConnectionForModel,
+			AgentName:               agentName,
+			APICallerName:           apiCallerName,
+			EnvironName:             environTrackerName,
+			NewControllerConnection: apicaller.NewExternalControllerConnection,
 
 			NewFirewallerWorker:      firewaller.NewWorker,
 			NewFirewallerFacade:      firewaller.NewFirewallerFacade,
@@ -292,7 +292,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		result[remoteRelationsName] = ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
 			AgentName:                agentName,
 			APICallerName:            apiCallerName,
-			NewAPIConnForModel:       api.NewConnectionForModel,
+			NewControllerConnection:  apicaller.NewExternalControllerConnection,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
 		}))

--- a/core/crossmodel/applicationurl.go
+++ b/core/crossmodel/applicationurl.go
@@ -53,6 +53,13 @@ func (u *ApplicationURL) String() string {
 	return u.Path()
 }
 
+// AsLocal returns a copy of the URL with an empty (local) source.
+func (u *ApplicationURL) AsLocal() *ApplicationURL {
+	localURL := *u
+	localURL.Source = ""
+	return &localURL
+}
+
 // HasEndpoint returns whether this application URL includes an
 // endpoint name in the application name.
 func (u *ApplicationURL) HasEndpoint() bool {

--- a/core/crossmodel/applicationurl_test.go
+++ b/core/crossmodel/applicationurl_test.go
@@ -169,3 +169,13 @@ func (s *ApplicationURLSuite) TestMakeURL(c *gc.C) {
 	url = crossmodel.MakeURL("user", "model", "app", "ctrl")
 	c.Assert(url, gc.Equals, "ctrl:user/model.app")
 }
+
+func (s *ApplicationURLSuite) TestAsLocal(c *gc.C) {
+	url, err := crossmodel.ParseApplicationURL("source:model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	expected, err := crossmodel.ParseApplicationURL("model.application:endpoint")
+	c.Assert(err, jc.ErrorIsNil)
+	original := *url
+	c.Assert(url.AsLocal(), gc.DeepEquals, expected)
+	c.Assert(*url, gc.DeepEquals, original)
+}

--- a/state/interface.go
+++ b/state/interface.go
@@ -103,6 +103,7 @@ type ModelAccessor interface {
 // access controller information.
 type ControllerAccessor interface {
 	ControllerConfig() (controller.Config, error)
+	ControllerInfo(modelUUID string) (ExternalController, error)
 }
 
 // UnitsWatcher defines the methods needed to retrieve an entity (a

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2853,5 +2853,4 @@ func (w *relationIngressWatcher) loop() error {
 			return tomb.ErrDying
 		}
 	}
-	return nil
 }

--- a/worker/apicaller/connect.go
+++ b/worker/apicaller/connect.go
@@ -266,3 +266,16 @@ func changePassword(oldPassword string, a agent.Agent, facade apiagent.ConnFacad
 	// end up locked out forever.
 	return facade.SetPassword(a.CurrentConfig().Tag(), newPassword)
 }
+
+// NewExternalControllerConnectionFunc returns a function returning an
+// api connection to a controller with the specified api info.
+type NewExternalControllerConnectionFunc func(*api.Info) (api.Connection, error)
+
+// NewExternalControllerConnection returns an api connection to a controller
+// with the specified api info.
+func NewExternalControllerConnection(apiInfo *api.Info) (api.Connection, error) {
+	return api.Open(apiInfo, api.DialOpts{
+		Timeout:    2 * time.Second,
+		RetryDelay: 500 * time.Millisecond,
+	})
+}

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -208,7 +208,7 @@ func (s *InstanceModeSuite) newFirewaller(c *gc.C) worker.Worker {
 		EnvironInstances:   s.Environ,
 		FirewallerAPI:      s.firewaller,
 		RemoteRelationsApi: s.remoteRelations,
-		NewCrossModelFacadeFunc: func(modelUUID string) (firewaller.CrossModelFirewallerFacadeCloser, error) {
+		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
 		Clock: s.mockClock,
@@ -905,7 +905,7 @@ func (s *GlobalModeSuite) newFirewaller(c *gc.C) worker.Worker {
 		EnvironInstances:   s.Environ,
 		FirewallerAPI:      s.firewaller,
 		RemoteRelationsApi: s.remoteRelations,
-		NewCrossModelFacadeFunc: func(modelUUID string) (firewaller.CrossModelFirewallerFacadeCloser, error) {
+		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
 	}
@@ -1152,7 +1152,7 @@ func (s *NoneModeSuite) TestStopImmediately(c *gc.C) {
 		EnvironInstances:   s.Environ,
 		FirewallerAPI:      s.firewaller,
 		RemoteRelationsApi: s.remoteRelations,
-		NewCrossModelFacadeFunc: func(modelUUID string) (firewaller.CrossModelFirewallerFacadeCloser, error) {
+		NewCrossModelFacadeFunc: func(*api.Info) (firewaller.CrossModelFirewallerFacadeCloser, error) {
 			return s.crossmodelFirewaller, nil
 		},
 	}

--- a/worker/firewaller/manifold.go
+++ b/worker/firewaller/manifold.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/remoterelations"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -22,7 +23,7 @@ type ManifoldConfig struct {
 	APICallerName string
 	EnvironName   string
 
-	NewAPIConnForModel       api.NewConnectionForModelFunc
+	NewControllerConnection  apicaller.NewExternalControllerConnectionFunc
 	NewRemoteRelationsFacade func(base.APICaller) (*remoterelations.Client, error)
 	NewFirewallerFacade      func(base.APICaller) (FirewallerAPI, error)
 	NewFirewallerWorker      func(Config) (worker.Worker, error)
@@ -51,8 +52,8 @@ func (cfg ManifoldConfig) Validate() error {
 	if cfg.EnvironName == "" {
 		return errors.NotValidf("empty EnvironName")
 	}
-	if cfg.NewAPIConnForModel == nil {
-		return errors.NotValidf("nil NewAPIConnForModel")
+	if cfg.NewControllerConnection == nil {
+		return errors.NotValidf("nil NewControllerConnection")
 	}
 	if cfg.NewRemoteRelationsFacade == nil {
 		return errors.NotValidf("nil NewRemoteRelationsFacade")
@@ -91,16 +92,6 @@ func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, erro
 		return nil, dependency.ErrUninstall
 	}
 
-	agentConf := agent.CurrentConfig()
-	apiInfo, ok := agentConf.APIInfo()
-	if !ok {
-		return nil, errors.New("no API connection details")
-	}
-	apiConnForModelFunc, err := cfg.NewAPIConnForModel(apiInfo)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	firewallerAPI, err := cfg.NewFirewallerFacade(apiConn)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -117,7 +108,7 @@ func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, erro
 		EnvironFirewaller:  environ,
 		EnvironInstances:   environ,
 		Mode:               mode,
-		NewCrossModelFacadeFunc: crossmodelFirewallerFacadeFunc(apiConnForModelFunc),
+		NewCrossModelFacadeFunc: crossmodelFirewallerFacadeFunc(cfg.NewControllerConnection),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/firewaller/manifold_test.go
+++ b/worker/firewaller/manifold_test.go
@@ -39,7 +39,7 @@ func (s *ManifoldSuite) TestManifoldFirewallModeNone(c *gc.C) {
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
 		EnvironName:              "environ",
-		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
+		NewControllerConnection:  func(*api.Info) (api.Connection, error) { return nil, nil },
 		NewFirewallerFacade:      func(base.APICaller) (firewaller.FirewallerAPI, error) { return nil, nil },
 		NewFirewallerWorker:      func(firewaller.Config) (worker.Worker, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (*remoterelations.Client, error) { return nil, nil },
@@ -86,7 +86,7 @@ func (s *ManifoldConfigSuite) validConfig() firewaller.ManifoldConfig {
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
 		EnvironName:              "environ",
-		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
+		NewControllerConnection:  func(*api.Info) (api.Connection, error) { return nil, nil },
 		NewFirewallerFacade:      func(base.APICaller) (firewaller.FirewallerAPI, error) { return nil, nil },
 		NewFirewallerWorker:      func(firewaller.Config) (worker.Worker, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (*remoterelations.Client, error) { return nil, nil },
@@ -122,9 +122,9 @@ func (s *ManifoldConfigSuite) TestMissingNewFirewallerWorker(c *gc.C) {
 	s.checkNotValid(c, "nil NewFirewallerWorker not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingNewAPIConnForModel(c *gc.C) {
-	s.config.NewAPIConnForModel = nil
-	s.checkNotValid(c, "nil NewAPIConnForModel not valid")
+func (s *ManifoldConfigSuite) TestMissingNewControllerConnection(c *gc.C) {
+	s.config.NewControllerConnection = nil
+	s.checkNotValid(c, "nil NewControllerConnection not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewRemoteRelationsFacade(c *gc.C) {

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/worker/apicaller"
 )
 
 // NewRemoteRelationsFacade creates a remote relations API facade.
@@ -43,10 +44,10 @@ func NewWorker(cfg Config) (worker.Worker, error) {
 
 // For now we use a facade, but in future this may evolve into a REST caller.
 func crossmodelFirewallerFacadeFunc(
-	apiConnForModelFunc func(string) (api.Connection, error),
-) func(string) (CrossModelFirewallerFacadeCloser, error) {
-	return func(modelUUID string) (CrossModelFirewallerFacadeCloser, error) {
-		conn, err := apiConnForModelFunc(modelUUID)
+	connectionFunc apicaller.NewExternalControllerConnectionFunc,
+) newCrossModelFacadeFunc {
+	return func(apiInfo *api.Info) (CrossModelFirewallerFacadeCloser, error) {
+		conn, err := connectionFunc(apiInfo)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/dependency"
 )
 
@@ -19,7 +20,7 @@ type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 
-	NewAPIConnForModel       api.NewConnectionForModelFunc
+	NewControllerConnection  apicaller.NewExternalControllerConnectionFunc
 	NewRemoteRelationsFacade func(base.APICaller) (RemoteRelationsFacade, error)
 	NewWorker                func(Config) (worker.Worker, error)
 }
@@ -32,8 +33,8 @@ func (config ManifoldConfig) Validate() error {
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
 	}
-	if config.NewAPIConnForModel == nil {
-		return errors.NotValidf("nil NewAPIConnForModel")
+	if config.NewControllerConnection == nil {
+		return errors.NotValidf("nil NewControllerConnection")
 	}
 	if config.NewRemoteRelationsFacade == nil {
 		return errors.NotValidf("nil NewRemoteRelationsFacade")
@@ -63,25 +64,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	agentConf := agent.CurrentConfig()
-	apiInfo, ok := agentConf.APIInfo()
-	if !ok {
-		return nil, errors.New("no API connection details")
-	}
-	// We use an anonymous connection and macaroon sent with the
-	// api requests for authentication.
-	apiInfo.Tag = nil
-	apiInfo.Password = ""
-	apiInfo.Macaroons = nil
-	apiConnForModelFunc, err := config.NewAPIConnForModel(apiInfo)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	w, err := config.NewWorker(Config{
 		ModelUUID:                agent.CurrentConfig().Model().Id(),
 		RelationsFacade:          facade,
-		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(apiConnForModelFunc),
+		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(config.NewControllerConnection),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -31,7 +31,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 	return remoterelations.ManifoldConfig{
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
-		NewAPIConnForModel:       func(*api.Info) (func(string) (api.Connection, error), error) { return nil, nil },
+		NewControllerConnection:  func(*api.Info) (api.Connection, error) { return nil, nil },
 		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 	}
@@ -61,9 +61,9 @@ func (s *ManifoldConfigSuite) TestMissingNewWorker(c *gc.C) {
 	s.checkNotValid(c, "nil NewWorker not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingNewAPIConnForModel(c *gc.C) {
-	s.config.NewAPIConnForModel = nil
-	s.checkNotValid(c, "nil NewAPIConnForModel not valid")
+func (s *ManifoldConfigSuite) TestMissingNewControllerConnection(c *gc.C) {
+	s.config.NewControllerConnection = nil
+	s.checkNotValid(c, "nil NewControllerConnection not valid")
 }
 
 func (s *ManifoldConfigSuite) checkNotValid(c *gc.C, expect string) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 	"gopkg.in/tomb.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 	"github.com/juju/juju/worker/remoterelations"
-	"gopkg.in/macaroon.v1"
 )
 
 type mockRelationsFacade struct {
@@ -28,6 +29,7 @@ type mockRelationsFacade struct {
 	relations                          map[string]*mockRelation
 	relationsEndpoints                 map[string]*relationEndpointInfo
 	relationsUnitsWatchers             map[string]*mockRelationUnitsWatcher
+	controllerInfo                     map[string]*api.Info
 }
 
 func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
@@ -39,6 +41,7 @@ func newMockRelationsFacade(stub *testing.Stub) *mockRelationsFacade {
 		remoteApplicationsWatcher:          newMockStringsWatcher(),
 		remoteApplicationRelationsWatchers: make(map[string]*mockStringsWatcher),
 		relationsUnitsWatchers:             make(map[string]*mockRelationUnitsWatcher),
+		controllerInfo:                     make(map[string]*api.Info),
 	}
 }
 
@@ -239,6 +242,14 @@ func (m *mockRelationsFacade) ConsumeRemoteRelationChange(change params.RemoteRe
 		return err
 	}
 	return nil
+}
+
+func (m *mockRelationsFacade) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) {
+	m.stub.MethodCall(m, "ControllerAPIInfoForModel", modelUUID)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.controllerInfo[modelUUID], nil
 }
 
 type mockRemoteRelationsFacade struct {

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/remoterelations"
+	"github.com/juju/juju/worker/apicaller"
 )
 
 func NewRemoteRelationsFacade(apiCaller base.APICaller) (RemoteRelationsFacade, error) {
@@ -39,10 +40,10 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 // For now we use a facade, but in future this may evolve into a REST caller.
 func remoteRelationsFacadeForModelFunc(
-	apiConnForModelFunc func(string) (api.Connection, error),
-) func(string) (RemoteModelRelationsFacadeCloser, error) {
-	return func(modelUUID string) (RemoteModelRelationsFacadeCloser, error) {
-		conn, err := apiConnForModelFunc(modelUUID)
+	connectionFunc apicaller.NewExternalControllerConnectionFunc,
+) newRemoteRelationsFacadeFunc {
+	return func(apiInfo *api.Info) (RemoteModelRelationsFacadeCloser, error) {
+		conn, err := connectionFunc(apiInfo)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Description of change

Cross model relations can now span controllers.

## QA steps

bootstrap controller bob
bootstrap controller mary
deploy mysql to mary, offer mysql
deploy mediawiki to bob
relate mediawiki:db mary:default.mysql
profit
