### PR TITLE
Add api facade for relation status watcher

### DIFF
--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -130,3 +130,23 @@ func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.Remote
 	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
 }
+
+// WatchRelationStatus starts a RelationStatusWatcher for watching the life and
+// status of the specified relation in the remote model.
+func (c *Client) WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
+	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{arg}}
+	var results params.RelationStatusWatchResults
+	err := c.facade.FacadeCall("WatchRelationsStatus", args, &results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	w := apiwatcher.NewRelationStatusWatcher(c.facade.RawAPICaller(), result)
+	return w, nil
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -70,6 +70,7 @@ var facadeVersions = map[string]int{
 	"Provisioner":                  3,
 	"ProxyUpdater":                 1,
 	"Reboot":                       2,
+	"RelationStatusWatcher":        1,
 	"RelationUnitsWatcher":         1,
 	"RemoteRelations":              1,
 	"Resources":                    1,

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -562,6 +562,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 	c.Assert(result.ModelTag, gc.Equals, s.State.ModelTag().String())
 	c.Assert(result.Facades, jc.DeepEquals, []params.FacadeVersions{
 		{Name: "CrossModelRelations", Versions: []int{1}},
+		{Name: "RelationStatusWatcher", Versions: []int{1}},
 		{Name: "RelationUnitsWatcher", Versions: []int{1}},
 		{Name: "StringsWatcher", Versions: []int{1}},
 	})

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -241,6 +241,7 @@ func AllFacades() *facade.Registry {
 	regRaw("AllModelWatcher", 2, NewAllWatcher, reflect.TypeOf((*SrvAllWatcher)(nil)))
 	regRaw("NotifyWatcher", 1, newNotifyWatcher, reflect.TypeOf((*srvNotifyWatcher)(nil)))
 	regRaw("StringsWatcher", 1, newStringsWatcher, reflect.TypeOf((*srvStringsWatcher)(nil)))
+	regRaw("RelationStatusWatcher", 1, newRelationStatusWatcher, reflect.TypeOf((*srvRelationStatusWatcher)(nil)))
 	regRaw("RelationUnitsWatcher", 1, newRelationUnitsWatcher, reflect.TypeOf((*srvRelationUnitsWatcher)(nil)))
 	regRaw("VolumeAttachmentsWatcher", 2, newVolumeAttachmentsWatcher, reflect.TypeOf((*srvMachineStorageIdsWatcher)(nil)))
 	regRaw("FilesystemAttachmentsWatcher", 2, newFilesystemAttachmentsWatcher, reflect.TypeOf((*srvMachineStorageIdsWatcher)(nil)))

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -80,6 +80,10 @@ type Relation interface {
 	// WatchUnits returns a watcher that notifies of changes to the units of the
 	// specified application in the relation.
 	WatchUnits(applicationName string) (state.RelationUnitsWatcher, error)
+
+	// WatchStatus returns a watcher that notifies of changes to the life
+	// or status of the relation.
+	WatchStatus() state.RelationStatusWatcher
 }
 
 // RelationUnit provides access to the settings of a single unit in a relation,

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -313,6 +313,9 @@ type RemoteRelationChangeEvent struct {
 	// Life is the current lifecycle state of the relation.
 	Life Life `json:"life"`
 
+	// Status is the current status of the relation.
+	Status RelationStatusValue `json:"status"`
+
 	// ChangedUnits maps unit tokens to relation unit changes.
 	ChangedUnits []RemoteRelationUnitChange `json:"changed-units,omitempty"`
 
@@ -322,6 +325,32 @@ type RemoteRelationChangeEvent struct {
 
 	// Macaroons are used for authentication.
 	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+}
+
+// RelationStatusChange describes the life and status of a relation.
+type RelationStatusChange struct {
+	// Key is the relation key of the changed relation.
+	Key string `json:"key"`
+
+	// Life is the life of the relation.
+	Life Life `json:"life"`
+
+	// Status is the status of the relation.
+	Status RelationStatusValue `json:"status"`
+}
+
+// RelationStatusWatchResult holds a RelationStatusWatcher id, baseline state
+// (in the Changes field), and an error (if any).
+type RelationStatusWatchResult struct {
+	RelationStatusWatcherId string                 `json:"watcher-id"`
+	Changes                 []RelationStatusChange `json:"changes"`
+	Error                   *Error                 `json:"error,omitempty"`
+}
+
+// RelationStatusWatchResults holds the results for any API call which ends up
+// returning a list of RelationStatusWatchers.
+type RelationStatusWatchResults struct {
+	Results []RelationStatusWatchResult `json:"results"`
 }
 
 // IngressNetworksChanges holds a set of IngressNetworksChangeEvent structures.

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -8,6 +8,7 @@ package params
 import (
 	"time"
 
+	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/instance"
 	"github.com/juju/juju/state/multiwatcher"
 )
@@ -267,4 +268,12 @@ const (
 	Alive Life = "alive"
 	Dying Life = "dying"
 	Dead  Life = "dead"
+)
+
+// RelationStatusValue describes the status of a relation ("active" or "revoked").
+type RelationStatusValue relation.Status
+
+const (
+	Active  RelationStatusValue = "active"
+	Revoked RelationStatusValue = "revoked"
 )

--- a/apiserver/restrict_anonymous.go
+++ b/apiserver/restrict_anonymous.go
@@ -15,6 +15,7 @@ import (
 // its own authentication and authorisation if required.
 var anonymousFacadeNames = set.NewStrings(
 	"CrossModelRelations",
+	"RelationStatusWatcher",
 	"RelationUnitsWatcher",
 	"StringsWatcher",
 )


### PR DESCRIPTION
## Description of change

There's a new relation status watcher - this PR adds the facade infrastructure to expose it.
There's the core watcher facade plus the hooks into the cross model relations facade so it can be used by the remote relation worker.

## QA steps

None yet.

