### PR TITLE
The remote relation worker handles the offer side relation dying

### DIFF
--- a/api/remoterelations/remoterelations.go
+++ b/api/remoterelations/remoterelations.go
@@ -252,7 +252,7 @@ func (c *Client) ConsumeRemoteRelationChange(change params.RemoteRelationChangeE
 		Changes: []params.RemoteRelationChangeEvent{change},
 	}
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("ConsumeRemoteRelationChange", args, &results)
+	err := c.facade.FacadeCall("ConsumeRemoteRelationChanges", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/remoterelations/remoterelations_test.go
+++ b/api/remoterelations/remoterelations_test.go
@@ -370,7 +370,7 @@ func (s *remoteRelationsSuite) TestConsumeRemoteRelationChange(c *gc.C) {
 		c.Check(objType, gc.Equals, "RemoteRelations")
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "ConsumeRemoteRelationChange")
+		c.Check(request, gc.Equals, "ConsumeRemoteRelationChanges")
 		c.Check(arg, jc.DeepEquals, changes)
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -376,9 +376,9 @@ func (api *RemoteRelationsAPI) WatchRemoteRelations() (params.StringsWatchResult
 	return params.StringsWatchResult{}, watcher.EnsureErr(w)
 }
 
-// ConsumeRemoteRelationChange consumes a change to settings originating
-// from the remote/offering side of a relation.
-func (api *RemoteRelationsAPI) ConsumeRemoteRelationChange(
+// ConsumeRemoteRelationChanges consumes changes to settings originating
+// from the remote/offering side of relations.
+func (api *RemoteRelationsAPI) ConsumeRemoteRelationChanges(
 	changes params.RemoteRelationsChanges,
 ) (params.ErrorResults, error) {
 	results := params.ErrorResults{

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -374,7 +374,7 @@ func (s *remoteRelationsSuite) TestConsumeRemoteRelationChange(c *gc.C) {
 	changes := params.RemoteRelationsChanges{
 		Changes: []params.RemoteRelationChangeEvent{change},
 	}
-	result, err := s.api.ConsumeRemoteRelationChange(changes)
+	result, err := s.api.ConsumeRemoteRelationChanges(changes)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.OneError(), gc.IsNil)
 

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -84,7 +84,7 @@ func (w *relationUnitsWorker) loop() error {
 		case change, ok := <-w.ruw.Changes():
 			if !ok {
 				// We are dying.
-				continue
+				return w.catacomb.ErrDying()
 			}
 			logger.Debugf("relation units changed for %v: %#v", w.relationTag, change)
 			if evt, err := w.relationUnitsChangeEvent(change); err != nil {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -45,6 +45,10 @@ type RemoteModelRelationsFacade interface {
 
 	// RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
 	RelationUnitSettings([]params.RemoteRelationUnit) ([]params.SettingsResult, error)
+
+	// WatchRemoteApplicationRelations starts a RelationStatusWatcher for watching the
+	// relations of each specified application in the remote model.
+	WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.


### PR DESCRIPTION
## Description of change

The remote relation worker on the consumer side now reacts to the offer side relation dying by making the local relation die as well.

## QA steps

Deploy a mediawiki-mysql cmr scenario.
Remove the relation on the mysql (offer) side.
The relation on the mediawiki side should die also.
