### PR TITLE
Wire up new cmr macaroon authenticator

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -942,6 +942,11 @@ func (s *state) Close() error {
 	return err
 }
 
+// BakeryClient implements api.Connection.
+func (s *state) BakeryClient() *httpbakery.Client {
+	return s.bakeryClient
+}
+
 // Broken implements api.Connection.
 func (s *state) Broken() <-chan struct{} {
 	return s.broken

--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/httprequest"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon-bakery.v1/httpbakery"
 )
 
 // APICaller is implemented by the client-facing State object.
@@ -38,6 +39,9 @@ type APICaller interface {
 	// Note that the URLs in HTTP requests passed to the Client.Do
 	// method should not include a host part.
 	HTTPClient() (*httprequest.Client, error)
+
+	// BakeryClient returns the bakery client for this connection.
+	BakeryClient() *httpbakery.Client
 
 	StreamConnector
 	ControllerStreamConnector

--- a/api/crossmodelrelations/crossmodelrelations.go
+++ b/api/crossmodelrelations/crossmodelrelations.go
@@ -5,12 +5,16 @@ package crossmodelrelations
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/watcher"
 )
+
+var logger = loggo.GetLogger("juju.api.crossmodelrelations")
 
 // Client provides access to the crossmodelrelations api facade.
 type Client struct {
@@ -28,6 +32,21 @@ func (c *Client) Close() error {
 	return c.ClientFacade.Close()
 }
 
+// handleError is used to process an error obtained when making a facade call.
+// If the error indicates that a macaroon discharge is required, this is done
+// and the resulting discharge macaroons passed back so the api call can be retried.
+func (c *Client) handleError(err error) (macaroon.Slice, error) {
+	if params.ErrCode(err) != params.CodeDischargeRequired {
+		return nil, err
+	}
+	errResp := errors.Cause(err).(*params.Error)
+	if errResp.Info == nil {
+		return nil, errors.Annotatef(err, "no error info found in discharge-required response error")
+	}
+	logger.Debugf("attempting to discharge macaroon due to error: %v", err)
+	return c.facade.RawAPICaller().BakeryClient().DischargeAll(errResp.Info.Macaroon)
+}
+
 // PublishRelationChange publishes relation changes to the
 // model hosting the remote application involved in the relation.
 func (c *Client) PublishRelationChange(change params.RemoteRelationChangeEvent) error {
@@ -35,17 +54,28 @@ func (c *Client) PublishRelationChange(change params.RemoteRelationChangeEvent) 
 		Changes: []params.RemoteRelationChangeEvent{change},
 	}
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("PublishRelationChanges", args, &results)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = results.OneError()
-	if err != nil {
-		if params.IsCodeNotFound(err) {
-			return errors.NotFoundf("relation for event %v", change)
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		err := c.facade.FacadeCall("PublishRelationChanges", args, &results)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = results.OneError()
+		if err != nil {
+			if params.IsCodeNotFound(err) {
+				return errors.NotFoundf("relation for event %v", change)
+			}
+			if i == 0 {
+				mac, err2 := c.handleError(err)
+				if err2 != nil {
+					err = errors.Wrap(err, err2)
+					return err
+				}
+				args.Changes[0].Macaroons = mac
+			}
 		}
 	}
-	return err
+	return results.OneError()
 }
 
 func (c *Client) PublishIngressNetworkChange(change params.IngressNetworksChangeEvent) error {
@@ -53,9 +83,21 @@ func (c *Client) PublishIngressNetworkChange(change params.IngressNetworksChange
 		Changes: []params.IngressNetworksChangeEvent{change},
 	}
 	var results params.ErrorResults
-	err := c.facade.FacadeCall("PublishIngressNetworkChanges", args, &results)
-	if err != nil {
-		return errors.Trace(err)
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		err := c.facade.FacadeCall("PublishIngressNetworkChanges", args, &results)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = results.OneError()
+		if err != nil && i == 0 {
+			mac, err2 := c.handleError(err)
+			if err2 != nil {
+				err = errors.Wrap(err, err2)
+				return err
+			}
+			args.Changes[0].Macaroons = mac
+		}
 	}
 	return results.OneError()
 }
@@ -63,16 +105,56 @@ func (c *Client) PublishIngressNetworkChange(change params.IngressNetworksChange
 // RegisterRemoteRelations sets up the remote model to participate
 // in the specified relations.
 func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelationArg) ([]params.RegisterRemoteRelationResult, error) {
-	args := params.RegisterRemoteRelationArgs{Relations: relations}
-	var results params.RegisterRemoteRelationResults
-	err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var (
+		args         params.RegisterRemoteRelationArgs
+		retryIndices []int
+	)
+
+	result := make([]params.RegisterRemoteRelationResult, len(relations))
+	args = params.RegisterRemoteRelationArgs{Relations: relations}
+
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		var results params.RegisterRemoteRelationResults
+		err := c.facade.FacadeCall("RegisterRemoteRelations", args, &results)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(results.Results) != len(args.Relations) {
+			return nil, errors.Errorf("expected %d result(s), got %d", len(args.Relations), len(results.Results))
+		}
+
+		if i == 0 {
+			args = params.RegisterRemoteRelationArgs{}
+			// Separate the successful calls from those needing a retry.
+			for j, res := range results.Results {
+				if res.Error == nil {
+					result[j] = res
+					continue
+				}
+				mac, err := c.handleError(res.Error)
+				if err != nil {
+					res.Error.Message = err.Error()
+					result[j] = res
+					continue
+				}
+				retryArg := relations[j]
+				retryArg.Macaroons = mac
+				args.Relations = append(args.Relations, retryArg)
+				retryIndices = append(retryIndices, i)
+			}
+			if len(args.Relations) == 0 {
+				break
+			}
+		}
+		// After a retry, insert the results into the original result slice.
+		if i == 1 {
+			for j, res := range results.Results {
+				result[retryIndices[j]] = res
+			}
+		}
 	}
-	if len(results.Results) != len(relations) {
-		return nil, errors.Errorf("expected %d result(s), got %d", len(relations), len(results.Results))
-	}
-	return results.Results, nil
+	return result, nil
 }
 
 // WatchRelationUnits returns a watcher that notifies of changes to the
@@ -80,16 +162,26 @@ func (c *Client) RegisterRemoteRelations(relations ...params.RegisterRemoteRelat
 func (c *Client) WatchRelationUnits(remoteRelationArg params.RemoteEntityArg) (watcher.RelationUnitsWatcher, error) {
 	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{remoteRelationArg}}
 	var results params.RelationUnitsWatchResults
-	err := c.facade.FacadeCall("WatchRelationUnits", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
+	var result params.RelationUnitsWatchResult
+
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		err := c.facade.FacadeCall("WatchRelationUnits", args, &results)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(results.Results) != 1 {
+			return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+		}
+		result = results.Results[0]
+		if result.Error != nil && i == 0 {
+			mac, err := c.handleError(result.Error)
+			if err != nil {
+				err = errors.Wrap(result.Error, err)
+				return nil, err
+			}
+			args.Args[0].Macaroons = mac
+		}
 	}
 	w := apiwatcher.NewRelationUnitsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
@@ -97,16 +189,54 @@ func (c *Client) WatchRelationUnits(remoteRelationArg params.RemoteEntityArg) (w
 
 // RelationUnitSettings returns the relation unit settings for the given relation units in the remote model.
 func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit) ([]params.SettingsResult, error) {
-	args := params.RemoteRelationUnits{relationUnits}
-	var results params.SettingsResults
-	err := c.facade.FacadeCall("RelationUnitSettings", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var (
+		args         params.RemoteRelationUnits
+		retryIndices []int
+	)
+
+	result := make([]params.SettingsResult, len(relationUnits))
+	args = params.RemoteRelationUnits{RelationUnits: relationUnits}
+
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		var results params.SettingsResults
+		err := c.facade.FacadeCall("RelationUnitSettings", args, &results)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(results.Results) != len(args.RelationUnits) {
+			return nil, errors.Errorf("expected %d result(s), got %d", len(args.RelationUnits), len(results.Results))
+		}
+
+		if i == 0 {
+			args = params.RemoteRelationUnits{}
+			for j, res := range results.Results {
+				if res.Error == nil {
+					result[j] = res
+					continue
+				}
+				mac, err := c.handleError(res.Error)
+				if err != nil {
+					res.Error.Message = err.Error()
+					result[j] = res
+					continue
+				}
+				retryArg := relationUnits[j]
+				retryArg.Macaroons = mac
+				args.RelationUnits = append(args.RelationUnits, retryArg)
+				retryIndices = append(retryIndices, i)
+			}
+			if len(args.RelationUnits) == 0 {
+				break
+			}
+		}
+		if i == 1 {
+			for j, res := range results.Results {
+				result[retryIndices[j]] = res
+			}
+		}
 	}
-	if len(results.Results) != len(relationUnits) {
-		return nil, errors.Errorf("expected %d result(s), got %d", len(relationUnits), len(results.Results))
-	}
-	return results.Results, nil
+	return result, nil
 }
 
 // WatchEgressAddressesForRelation returns a watcher that notifies when addresses,
@@ -116,16 +246,26 @@ func (c *Client) RelationUnitSettings(relationUnits []params.RemoteRelationUnit)
 func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.RemoteEntityArg) (watcher.StringsWatcher, error) {
 	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{remoteRelationArg}}
 	var results params.StringsWatchResults
-	err := c.facade.FacadeCall("WatchEgressAddressesForRelations", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
+	var result params.StringsWatchResult
+
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		err := c.facade.FacadeCall("WatchEgressAddressesForRelations", args, &results)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(results.Results) != 1 {
+			return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+		}
+		result = results.Results[0]
+		if result.Error != nil && i == 0 {
+			mac, err := c.handleError(result.Error)
+			if err != nil {
+				err = errors.Wrap(result.Error, err)
+				return nil, err
+			}
+			args.Args[0].Macaroons = mac
+		}
 	}
 	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
@@ -136,16 +276,26 @@ func (c *Client) WatchEgressAddressesForRelation(remoteRelationArg params.Remote
 func (c *Client) WatchRelationStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
 	args := params.RemoteEntityArgs{Args: []params.RemoteEntityArg{arg}}
 	var results params.RelationStatusWatchResults
-	err := c.facade.FacadeCall("WatchRelationsStatus", args, &results)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		return nil, result.Error
+	var result params.RelationStatusWatchResult
+
+	// We make up to 2 api calls - the second is a retry after a macaroon discharge is obtained.
+	for i := 0; i < 2; i++ {
+		err := c.facade.FacadeCall("WatchRelationsStatus", args, &results)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(results.Results) != 1 {
+			return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
+		}
+		result = results.Results[0]
+		if result.Error != nil && i == 0 {
+			mac, err := c.handleError(result.Error)
+			if err != nil {
+				err = errors.Wrap(result.Error, err)
+				return nil, err
+			}
+			args.Args[0].Macaroons = mac
+		}
 	}
 	w := apiwatcher.NewRelationStatusWatcher(c.facade.RawAPICaller(), result)
 	return w, nil

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/names.v2"
 	worker "gopkg.in/juju/worker.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon.v1"
 
@@ -19,12 +20,13 @@ import (
 	"github.com/juju/juju/api/crossmodelrelations"
 	"github.com/juju/juju/api/migrationminion"
 	"github.com/juju/juju/api/watcher"
-	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/permission"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -258,13 +260,41 @@ func (s *watcherSuite) assertRelationStatusWatchResult(c *gc.C, rel *state.Relat
 	token, err := re.ExportLocalEntity(rel.Tag())
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Create the offer connection details.
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
+	offers := state.NewApplicationOffers(s.State)
+	_, err = offers.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:       "hosted-mysql",
+		ApplicationName: "mysql",
+		Owner:           "admin",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		OfferName:       "hosted-mysql",
+		Username:        "fred",
+		RelationKey:     rel.String(),
+		RelationId:      rel.Id(),
+		SourceModelUUID: s.State.ModelUUID(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add the consume permission for the offer so the macaroon
+	// discharge can occur.
+	err = s.State.CreateOfferAccess(
+		names.NewApplicationOfferTag("hosted-mysql"),
+		names.NewUserTag("fred"), permission.ConsumeAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Create a macaroon for authorisation.
-	bakery, err := crossmodel.NewBakery(s.State)
+	bakery, err := bakery.NewService(bakery.NewServiceParams{
+		Location: "juju model " + s.State.ModelUUID(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	mac, err := bakery.NewMacaroon(fmt.Sprintf("%v %v", s.State.ModelTag(), rel.Tag()), nil,
 		[]checkers.Caveat{
 			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
 			checkers.DeclaredCaveat("relation-key", rel.String()),
+			checkers.DeclaredCaveat("username", "fred"),
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -402,7 +402,7 @@ func (a *admin) checkControllerMachineCreds(req params.LoginRequest) (state.Enti
 }
 
 func (a *admin) authenticator() authentication.EntityAuthenticator {
-	return a.srv.authCtxt.authenticator(a.root.serverHost)
+	return a.srv.loginAuthCtxt.authenticator(a.root.serverHost)
 }
 
 func (a *admin) maintenanceInProgress() bool {

--- a/apiserver/authcontext.go
+++ b/apiserver/authcontext.go
@@ -209,7 +209,7 @@ var errMacaroonAuthNotConfigured = errors.New("macaroon authentication is not co
 
 // newExternalMacaroonAuth returns an authenticator that can authenticate
 // macaroon-based logins for external users. This is just a helper function
-// for authCtxt.externalMacaroonAuth.
+// for loginAuthCtxt.externalMacaroonAuth.
 func newExternalMacaroonAuth(st *state.State) (*authentication.ExternalMacaroonAuthenticator, error) {
 	controllerCfg, err := st.ControllerConfig()
 	if err != nil {

--- a/apiserver/common/crossmodel/auth.go
+++ b/apiserver/common/crossmodel/auth.go
@@ -19,25 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/state"
 )
-
-// NewBakery returns a bakery used for minting macaroons used
-// in cross model relations.
-// TODO(wallyworld) - this will be removed next PR
-func NewBakery(st *state.State) (*bakery.Service, error) {
-	store, err := st.NewBakeryStorage()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	// TODO(wallyworld) - shorten the exipry time when macaroon
-	// refresh is supported.
-	store = store.ExpireAfter(5 * 24 * 365 * time.Hour)
-	return bakery.NewService(bakery.NewServiceParams{
-		Location: "juju model " + st.ModelUUID(),
-		Store:    store,
-	})
-}
 
 const (
 	usernameKey    = "username"

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -33,7 +33,7 @@ var (
 )
 
 func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
-	auth, err := srv.authCtxt.externalMacaroonAuth()
+	auth, err := srv.loginAuthCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func ServerMacaroon(srv *Server) (*macaroon.Macaroon, error) {
 }
 
 func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
-	auth, err := srv.authCtxt.externalMacaroonAuth()
+	auth, err := srv.loginAuthCtxt.externalMacaroonAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func ServerBakeryService(srv *Server) (authentication.BakeryService, error) {
 // ServerAuthenticatorForTag calls the authenticatorForTag method
 // of the server's authContext.
 func ServerAuthenticatorForTag(srv *Server, tag names.Tag) (authentication.EntityAuthenticator, error) {
-	return srv.authCtxt.authenticator("testing.invalid:1234").authenticatorForTag(tag)
+	return srv.loginAuthCtxt.authenticator("testing.invalid:1234").authenticatorForTag(tag)
 }
 
 func APIHandlerWithEntity(entity state.Entity) *apiHandler {
@@ -98,9 +98,9 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 	authCtxt, err := newAuthContext(pool.SystemState())
 	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
-		authCtxt:  authCtxt,
-		statePool: pool,
-		tag:       names.NewMachineTag("0"),
+		loginAuthCtxt: authCtxt,
+		statePool:     pool,
+		tag:           names.NewMachineTag("0"),
 	}
 	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
@@ -36,8 +37,10 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 	resources := common.NewResources()
 	resources.RegisterNamed("dataDir", common.StringResource(c.MkDir()))
 	var err error
+	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, s.bakery, s.bakery)
+	c.Assert(err, jc.ErrorIsNil)
 	s.api, err = applicationoffers.CreateOffersAPI(
-		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources, &mockBakeryService{},
+		getApplicationOffers, nil, s.mockState, s.mockStatePool, s.authorizer, resources, s.authContext,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
@@ -302,7 +303,7 @@ func makeOfferFilterFromParams(filter params.OfferFilter) jujucrossmodel.Applica
 }
 
 func (api *BaseAPI) makeOfferParams(backend Backend, offer *jujucrossmodel.ApplicationOffer, access permission.Access) (
-	*params.ApplicationOffer, Application, error,
+	*params.ApplicationOffer, crossmodel.Application, error,
 ) {
 	app, err := backend.Application(offer.ApplicationName)
 	if err != nil {

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
 	"github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
@@ -36,6 +37,7 @@ type baseSuite struct {
 	mockStatePool     *mockStatePool
 	env               *mockEnviron
 	bakery            *mockBakeryService
+	authContext       *crossmodel.AuthContext
 	applicationOffers *stubApplicationOffers
 }
 
@@ -87,7 +89,7 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string) {
 		return []jujucrossmodel.ApplicationOffer{anOffer}, nil
 	}
 	ch := &mockCharm{meta: &charm.Meta{Description: "A pretty popular database"}}
-	s.mockState.applications = map[string]applicationoffers.Application{
+	s.mockState.applications = map[string]crossmodel.Application{
 		"test": &mockApplication{
 			charm: ch, curl: charm.MustParseURL("db2-2"),
 			bindings: map[string]string{"db2": "myspace"},

--- a/apiserver/facades/controller/crossmodelrelations/state.go
+++ b/apiserver/facades/controller/crossmodelrelations/state.go
@@ -25,6 +25,9 @@ type CrossModelRelationsState interface {
 	// AddOfferConnection creates a new offer connection record, which records details about a
 	// relation made from a remote model to an offer in the local model.
 	AddOfferConnection(state.AddOfferConnectionParams) (OfferConnection, error)
+
+	// OfferConnectionForRelation returns the offer connection details for the given relation key.
+	OfferConnectionForRelation(string) (OfferConnection, error)
 }
 
 type stateShim struct {
@@ -41,6 +44,10 @@ func (st stateShim) AddOfferConnection(arg state.AddOfferConnectionParams) (Offe
 	return st.st.AddOfferConnection(arg)
 }
 
+func (st stateShim) OfferConnectionForRelation(relationKey string) (OfferConnection, error) {
+	return st.st.OfferConnectionForRelation(relationKey)
+}
+
 type Model interface {
 	Name() string
 	Owner() names.UserTag
@@ -50,4 +57,6 @@ func (st stateShim) Model() (Model, error) {
 	return st.st.Model()
 }
 
-type OfferConnection interface{}
+type OfferConnection interface {
+	OfferName() string
+}

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -74,7 +74,7 @@ func (ctxt *httpContext) stateForRequestAuthenticated(r *http.Request) (
 	if err != nil {
 		return nil, nil, nil, errors.NewUnauthorized(err, "")
 	}
-	authenticator := ctxt.srv.authCtxt.authenticator(r.Host)
+	authenticator := ctxt.srv.loginAuthCtxt.authenticator(r.Host)
 	entity, _, err := checkCreds(st, req, true, authenticator)
 	if err != nil {
 		if common.IsDischargeRequiredError(err) {

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -1,0 +1,80 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+
+	"github.com/juju/juju/apiserver/common/crossmodel"
+	"github.com/juju/juju/state"
+)
+
+const (
+	localOfferAccessLocationPath = "/offeraccess"
+)
+
+type localOfferAuthHandler struct {
+	authCtx *crossmodel.AuthContext
+}
+
+func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error) {
+	// Create a bakery service for discharging third-party caveats for
+	// local offer access authentication. This service does not persist keys;
+	// its macaroons should be very short-lived.
+	st := pool.SystemState()
+	localOfferThirdPartyBakeryService, _, err := newBakeryService(st, nil, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Create a bakery service for local offer access authentication. This service
+	// persists keys into MongoDB in a TTL collection.
+	store, err := st.NewBakeryStorage()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	locator := bakeryServicePublicKeyLocator{localOfferThirdPartyBakeryService}
+	localUserBakeryService, localUserBakeryServiceKey, err := newBakeryService(
+		st, store, locator,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	localOfferBakeryService := &expirableStorageBakeryService{
+		localUserBakeryService, localUserBakeryServiceKey, store, locator,
+	}
+	authCtx, err := crossmodel.NewAuthContext(crossmodel.GetStatePool(pool), localOfferThirdPartyBakeryService, localOfferBakeryService)
+	if err != nil {
+		return nil, err
+	}
+	return authCtx, nil
+}
+
+func (h *localOfferAuthHandler) checkThirdPartyCaveat(req *http.Request, cavId, cav string) ([]checkers.Caveat, error) {
+	ctx := &macaroonOfferAuthContext{h.authCtx, req}
+	return ctx.CheckThirdPartyCaveat(cavId, cav)
+}
+
+type macaroonOfferAuthContext struct {
+	*crossmodel.AuthContext
+	req *http.Request
+}
+
+// CheckThirdPartyCaveat is part of the bakery.ThirdPartyChecker interface.
+func (ctx *macaroonOfferAuthContext) CheckThirdPartyCaveat(cavId, cav string) ([]checkers.Caveat, error) {
+	logger.Debugf("check third party caveat %v: %v", cavId, cav)
+	details, err := ctx.CheckOfferAccessCaveat(cav)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	firstPartyCaveats, err := ctx.CheckLocalAccessRequest(details)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return firstPartyCaveats, nil
+}

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -58,7 +58,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 
 	// Set a short-lived macaroon as a cookie on the response,
 	// which the client can use to obtain a discharge macaroon.
-	m, err := h.ctxt.srv.authCtxt.CreateLocalLoginMacaroon(userTag)
+	m, err := h.ctxt.srv.loginAuthCtxt.CreateLocalLoginMacaroon(userTag)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)


### PR DESCRIPTION
## Description of change

Hook the new cross model offer authenticator into the api server. This provides a http endpoint for discharging the "has-offer-permission" third party caveat. Now, macaroons used to validate access to ffers are given a 2 minute expiry time. When they expire, a discharge error pointing to the new endpoint is generated.

The crossmodel api facade methods all now have the capability to transparently recognise the discharge error and perform the discharge. The workers which use the facade are none  the wiser. The facade methods essentially try the facade call up to 2 times - once initially, and then a second time with discharge macaroon if the first time failed with a discharge error and the third party caveats could be successfully discharged. To make this all possible, the bakery client off the api connection is exposed so it can be used to do the discharge in the api client.

## QA steps

Run up a CMR scenario and check logs for errors.
Everything should work as previously with the old auth.
